### PR TITLE
resize should go first

### DIFF
--- a/lib/THC/THCTensorMath.cu
+++ b/lib/THC/THCTensorMath.cu
@@ -89,8 +89,8 @@ void THCudaTensor_cadd(THCudaTensor *self_, float value, THCudaTensor *src)
 
 void THCudaTensor_cadd_tst(THCudaTensor *self_, THCudaTensor* src1, float value, THCudaTensor *src2)
 {
-  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   {
     THCudaTensor *self = THCudaTensor_newContiguous(self_);
 
@@ -109,8 +109,8 @@ void THCudaTensor_cadd_tst(THCudaTensor *self_, THCudaTensor* src1, float value,
 
 void THCudaTensor_cmul(THCudaTensor *self_, THCudaTensor *src1, THCudaTensor *src2)
 {
-  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   {
     THCudaTensor *self = THCudaTensor_newContiguous(self_);
     long size = THCudaTensor_nElement(self);
@@ -156,8 +156,8 @@ __global__ void THCudaTensor_kernel_addcmul(float *data, float value, float *src
 
 void THCudaTensor_addcmul(THCudaTensor *self_, float value, THCudaTensor *src1, THCudaTensor *src2)
 {
-  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   {
     THCudaTensor *self = THCudaTensor_newContiguous(self_);
     long size = THCudaTensor_nElement(self);
@@ -192,8 +192,8 @@ __global__ void THCudaTensor_kernel_addcdiv(float *data, float value, float *src
 
 void THCudaTensor_addcdiv(THCudaTensor *self_, float value, THCudaTensor *src1, THCudaTensor *src2)
 {
-  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   {
     THCudaTensor *self = THCudaTensor_newContiguous(self_);
     long size = THCudaTensor_nElement(self);
@@ -932,8 +932,8 @@ void THCudaTensor_neValue(THCudaTensor *self_, THCudaTensor *src, float value)
 template<class Op>
 void THCudaTensor_logicalTensor(THCudaTensor *self_, THCudaTensor *src1, THCudaTensor *src2, Op op)
 {
-  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
   THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size do not match");
 
   THCudaTensor *self = THCudaTensor_newContiguous(self_);
   long size = THCudaTensor_nElement(self);


### PR DESCRIPTION
This PR fixes a bug that I introduces in my last PR where the result resize should go before the argcheck because src1 is sometimes equal to result.
