### PR TITLE
torch.CudaTensor:isSameSizeAs()

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -383,9 +383,9 @@ function test.isSameSizeAs()
    local t3 = torch.CudaTensor(1, 9, 3, 3)
    local t4 = torch.CudaTensor(3, 4, 9, 10)
 
-   mytester:assert(t1:isSameSizeAs(t2) == false, "wrong answer ")
-   mytester:assert(t1:isSameSizeAs(t3) == false, "wrong answer ")
-   mytester:assert(t1:isSameSizeAs(t4) == true, "wrong answer ")
+   tester:assert(t1:isSameSizeAs(t2) == false, "wrong answer ")
+   tester:assert(t1:isSameSizeAs(t3) == false, "wrong answer ")
+   tester:assert(t1:isSameSizeAs(t4) == true, "wrong answer ")
 end
 
 function cutorch.test(tests)

--- a/torch/generic/Tensor.c
+++ b/torch/generic/Tensor.c
@@ -516,7 +516,7 @@ static int torch_Tensor_(isSameSizeAs)(lua_State *L)
 {
   THTensor *self = luaT_checkudata(L, 1, torch_Tensor);
   THTensor *src = luaT_checkudata(L, 2, torch_Tensor);
-  lua_pushboolean(L, THTensor_(isSameSizeAs)(tensor));
+  lua_pushboolean(L, THTensor_(isSameSizeAs)(self, src));
   return 1;
 }
 


### PR DESCRIPTION
This PR adds support for Soumith's new torch.isSameSizeAs() method for torch.CudaTensors. Unit tested.
