### PR TITLE
Tensor:cdiv with three arguments

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -214,6 +214,7 @@ interface:wrap("cmul",
 interface:wrap("cdiv",
                cname("cdiv"),
                {{name="CudaTensor", returned=true},
+                {name="CudaTensor", default=1},
                 {name="CudaTensor"}})
 
 interface:wrap("addcmul",

--- a/lib/THC/THCTensorMath.cu
+++ b/lib/THC/THCTensorMath.cu
@@ -128,19 +128,23 @@ void THCudaTensor_cmul(THCudaTensor *self_, THCudaTensor *src1, THCudaTensor *sr
   }
 }
 
-void THCudaTensor_cdiv(THCudaTensor *self_, THCudaTensor *src)
+void THCudaTensor_cdiv(THCudaTensor *self_, THCudaTensor *src1, THCudaTensor *src2)
 {
-  THArgCheck(THCudaTensor_nElement(self_) == THCudaTensor_nElement(src), 2, "size do not match");
+  THCudaTensor_resizeAs(self_, src1);
+  THArgCheck(THCudaTensor_nElement(src1) == THCudaTensor_nElement(src2), 3, "size does not match");
   {
     THCudaTensor *self = THCudaTensor_newContiguous(self_);
     long size = THCudaTensor_nElement(self);
-    src = THCudaTensor_newContiguous(src);
+    src1 = THCudaTensor_newContiguous(src1);
+    src2 = THCudaTensor_newContiguous(src2);
     thrust::device_ptr<float> self_data(THCudaTensor_data(self));
-    thrust::device_ptr<float> src_data(THCudaTensor_data(src));
+    thrust::device_ptr<float> src1_data(THCudaTensor_data(src1));
+    thrust::device_ptr<float> src2_data(THCudaTensor_data(src2));
 
-    thrust::transform(self_data, self_data+size, src_data, self_data, thrust::divides<float>());
+    thrust::transform(src1_data, src1_data+size, src2_data, self_data, thrust::divides<float>());
 
-    THCudaTensor_free(src);
+    THCudaTensor_free(src1);
+    THCudaTensor_free(src2);
     THCudaTensor_freeCopyTo(self, self_);
   }
 }

--- a/lib/THC/THCTensorMath.h
+++ b/lib/THC/THCTensorMath.h
@@ -14,7 +14,7 @@ THC_API void THCudaTensor_div(THCudaTensor *self, float value);
 THC_API void THCudaTensor_cadd(THCudaTensor *self, float value, THCudaTensor *src);  
 THC_API void THCudaTensor_cadd_tst(THCudaTensor *self, THCudaTensor *src1, float value, THCudaTensor *src2);
 THC_API void THCudaTensor_cmul(THCudaTensor *self, THCudaTensor *src1, THCudaTensor *src2);
-THC_API void THCudaTensor_cdiv(THCudaTensor *self, THCudaTensor *src);
+THC_API void THCudaTensor_cdiv(THCudaTensor *self, THCudaTensor *src1, THCudaTensor *src2);
 
 THC_API void THCudaTensor_addcmul(THCudaTensor *self, float value, THCudaTensor *src1, THCudaTensor *src2);
 THC_API void THCudaTensor_addcdiv(THCudaTensor *self, float value, THCudaTensor *src1, THCudaTensor *src2);

--- a/test/test.lua
+++ b/test/test.lua
@@ -160,6 +160,15 @@ function test.cdiv()
    compareFloatAndCudaTensorArgs(x, 'cdiv', y)
 end
 
+function test.cdiv3()
+   local sz1 = math.floor(torch.uniform(minsize,maxsize))
+   local sz2 = math.floor(torch.uniform(minsize,maxsize))
+   local x = torch.FloatTensor():rand(sz1, sz2)
+   local y = torch.FloatTensor():rand(sz1, sz2)
+   local z = torch.FloatTensor(sz1, sz2)
+   compareFloatAndCudaTensorArgs(z, 'cdiv', x, y)
+end
+
 function test.addcmul()
    local sz1 = math.floor(torch.uniform(minsize,maxsize))
    local sz2 = math.floor(torch.uniform(minsize,maxsize))


### PR DESCRIPTION
Torch tensors support the cdiv operation with both two and three arguments.
cutorch only supports the two-argument (in-place) version. This patch extends it
to also support the three-argument version and adds a test for it. The
implementation is very similar to cmul which already supports both two and three
arguments.
