### PR TITLE
fixes non-contiguous copy bug

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -136,6 +136,30 @@ function test.copyNoncontiguous()
       return src.new(sz, sz):copy(src[{{},{},{2}}])
    end
    compareFloatAndCuda(x, f)
+   
+   x = torch.FloatTensor():rand(2, sz, sz)
+   local f = function(src)
+      return src.new(sz, sz):copy(src[{{2},{},{}}])
+   end
+   compareFloatAndCuda(x, f)
+   
+   x = torch.FloatTensor():rand(sz, 2, sz)
+   local f = function(src)
+      return src.new(sz, sz):copy(src[{{},{2},{}}])
+   end
+   compareFloatAndCuda(x, f)
+   
+   x = torch.FloatTensor():rand(sz, 2, sz)
+   local f = function(src)
+      return src.new(sz, 1, sz):copy(src[{{},{2},{}}])
+   end
+   compareFloatAndCuda(x, f)
+   
+   x = torch.FloatTensor():rand(sz, sz):transpose(1,2)
+   local f = function(src)
+      return src.new(sz, sz):copy(src)
+   end
+   compareFloatAndCuda(x, f)
 end
 
 function test.largeNoncontiguous()


### PR DESCRIPTION
This PR fixes #39 . Basically, to fix the bug, I modified the `THCudaTensor_computesz` function to return sizes without any of the size=1 dimensions. It includes additional unit tests. 
