### PR TITLE
torch.CudaTensor.squeeze

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -390,6 +390,39 @@ interface:wrap("dist",
                 {name="CudaTensor"},
                 {name="float", default=2},
                 {name="float", creturned=true}})
+                
+interface:wrap("squeeze",
+        cname("squeeze"),
+        {{name="CudaTensor", default=true, returned=true, postcall=function(arg)
+                                                                local txt = {}
+                                                                if arg.returned then
+                                                                   table.insert(txt, string.format('if(arg%d->nDimension == 1 && arg%d->size[0] == 1)', arg.i, arg.i)) -- number
+                                                                   table.insert(txt, string.format('lua_pushnumber(L, (lua_Number)(*THCudaTensor_data(arg%d)));', arg.i))
+                                                                end
+                                                                return table.concat(txt, '\n')
+                                                             end},
+         {name="CudaTensor"}},
+        cname("squeeze1d"),
+        {{name="CudaTensor", default=true, returned=true,
+
+          postcall=
+             function(arg)
+                local txt = {}
+                if arg.returned then
+                   table.insert(txt, string.format('if(!hasdims && arg%d->nDimension == 1 && arg%d->size[0] == 1)', arg.i, arg.i)) -- number
+                   table.insert(txt, string.format('lua_pushnumber(L, (lua_Number)(*THCudaTensor_data(arg%d)));}', arg.i))
+                end
+                return table.concat(txt, '\n')
+             end},
+
+         {name="CudaTensor",
+
+          precall=
+             function(arg)
+                return string.format('{int hasdims = arg%d->nDimension > 1;', arg.i)
+             end},
+
+         {name="index"}})
 
 interface:register("cutorch_CudaTensorMath__")
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -85,6 +85,21 @@ local function compareFloatAndCudaTensorArgs(x, fn, ...)
       string.format("Divergent results between CPU and CUDA for function '%s'", fn))
 end
 
+function test.squeeze()
+   local sz = math.floor(torch.uniform(minsize,maxsize))
+   local x = torch.FloatTensor():rand(sz, 1, sz, 1)
+   compareFloatAndCuda(x, 'squeeze')
+   
+   local y = x:cuda():squeeze()
+   tester:assert(y:dim() == 2, "squeeze err")
+   
+   x = torch.FloatTensor():rand(sz, 1, 1, sz)
+   compareFloatAndCuda(x, 'squeeze', 2)
+   
+   local y = x:cuda():squeeze(2)
+   tester:assert(y:dim() == 3, "squeeze1d err")
+end
+
 function test.expand()
    local sz = math.floor(torch.uniform(minsize,maxsize))
    local x = torch.FloatTensor():rand(sz, 1)
@@ -98,28 +113,18 @@ function test.view()
    local sz = math.floor(torch.uniform(minsize,maxsize))
    local x = torch.FloatTensor():rand(sz, 3)
    compareFloatAndCuda(x, 'view', sz, 3, 1)
-
-   x = x:cuda()
-   compareFloatAndCuda(x, 'view', sz, 3, 1)
 end
 
 function test.viewAs()
    local sz = math.floor(torch.uniform(minsize,maxsize))
    local x = torch.FloatTensor():rand(sz, 3)
    local y = torch.FloatTensor():rand(sz, 3, 1)
-   compareFloatAndCuda(x, 'viewAs', y)
-
-   x = x:cuda()
-   y = y:cuda()
-   compareFloatAndCuda(x, 'viewAs', y)
+   compareFloatAndCudaTensorArgs(x, 'viewAs', y)
 end
 
 function test.repeatTensor()
    local sz = math.floor(torch.uniform(minsize,maxsize))
    local x = torch.FloatTensor():rand(sz, 3)
-   compareFloatAndCuda(x, 'repeatTensor', sz, 2)
-
-   x = x:cuda()
    compareFloatAndCuda(x, 'repeatTensor', sz, 2)
 end
 


### PR DESCRIPTION
This PR adds support for `torch.squeeze` to `torch.CudaTensors`. It includes unit tests. 

I also simplified `expand`, `viewAs` and `repeatTensor` unit tests (they were retesting things that were already tested within `compareFloatAndCuda`.
