### PR TITLE
One random number generator per GPU.

### DIFF
--- a/init.c
+++ b/init.c
@@ -39,6 +39,7 @@ static int cutorch_setDevice(lua_State *L)
 {
   int device = (int)luaL_checknumber(L, 1)-1;
   THCudaCheck(cudaSetDevice(device));
+  THCRandom_setGenerator(device);
   return 0;
 }
 
@@ -128,8 +129,6 @@ int luaopen_libcutorch(lua_State *L)
   luaL_register(L, NULL, cutorch_stuff__);
 
   THCudaInit();
-
-  THCRandom_seed();
 
   cutorch_CudaStorage_init(L);
   cutorch_CudaTensor_init(L);

--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -13,11 +13,12 @@ void THCudaInit(void)
   int device = 0;
   THCudaCheck(cudaGetDevice(&device));
 
+  THCRandom_init(count, device);
+
   int i,j;
   for(i=0; i < count; ++i)
   {
     THCudaCheck(cudaSetDevice(i));
-    THCRandom_manualSeed(THCRandom_initialSeed());
     for (j=0; j < count; ++j)
     {
       if(i != j)
@@ -34,6 +35,8 @@ void THCudaInit(void)
 
 void THCudaShutdown(void)
 {
+  THCRandom_shutdown();
+
   if(cublasShutdown() != CUBLAS_STATUS_SUCCESS)
     THError("unable to shutdown cublas");
 }

--- a/lib/THC/THCTensorRandom.h
+++ b/lib/THC/THCTensorRandom.h
@@ -3,6 +3,9 @@
 
 #include "THCTensor.h"
 
+THC_API void THCRandom_init(int num_devices, int current_device);
+THC_API void THCRandom_shutdown();
+THC_API void THCRandom_setGenerator(int device);
 THC_API unsigned long THCRandom_seed();
 THC_API void THCRandom_manualSeed(unsigned long the_seed_);
 THC_API unsigned long THCRandom_initialSeed();


### PR DESCRIPTION
Instead of having a single generator shared between GPUs, create a seperate
generator for each GPU. A generator is only initialized when the corresponding
GPU is being used.
