### PR TITLE
Fix computation of number of thread blocks in random number generator.

### DIFF
--- a/lib/THC/THCGeneral.h
+++ b/lib/THC/THCGeneral.h
@@ -23,6 +23,10 @@
 # define THC_API THC_EXTERNC
 #endif
 
+#ifndef DIVUP
+#define DIVUP(x, y) (((x) + (y) - 1) / (y))
+#endif
+
 THC_API void THCudaInit(void);
 THC_API void THCudaShutdown(void);
 

--- a/lib/THC/THCTensorCopy.cu
+++ b/lib/THC/THCTensorCopy.cu
@@ -2,10 +2,6 @@
 #include "THCGeneral.h"
 #include "THCTensor.h"
 
-#ifndef DIVUP
-#define DIVUP(x, y) (((x) + (y) - 1) / (y))
-#endif
-
 // Copy self->size to device and remove all dims of size=1
 static void THCudaTensor_computesz(THCudaTensor *self, long **sz_, long **st_, int *dim_, long *innermostdim)
 {

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -197,7 +197,7 @@ __global__ void generate_log_normal(curandStateMtgp32 *state, int size, float *r
   }
 }
 
-#define NUM_BLOCKS min((int)(size / BLOCK_SIZE), MAX_NUM_BLOCKS)
+#define NUM_BLOCKS min((int)DIVUP(size, BLOCK_SIZE), MAX_NUM_BLOCKS)
 THC_API void THCudaTensor_uniform(THCudaTensor *self_, double a, double b)
 {
   if (current_gen == NULL)


### PR DESCRIPTION
Move definition of DIVUP from THCTensorCopy.cu to THCGeneral.h.
Use DIVUP to compute the number of thread blocks for random number
generation.
