### PR TITLE
Move global RNG state into cutorch table.

### DIFF
--- a/init.c
+++ b/init.c
@@ -35,11 +35,20 @@ static int cutorch_getDeviceCount(lua_State *L)
   return 1;
 }
 
+static THCudaState* getState(lua_State *L)
+{
+  lua_getglobal(L, "cutorch");
+  lua_getfield(L, -1, "_state");
+  THCudaState *state = lua_touserdata(L, -1);
+  lua_pop(L, 2);
+  return state;
+}
+
 static int cutorch_setDevice(lua_State *L)
 {
   int device = (int)luaL_checknumber(L, 1)-1;
   THCudaCheck(cudaSetDevice(device));
-  THCRandom_setGenerator(device);
+  THCRandom_setGenerator(getState(L)->rngState, device);
   THCudaBlas_setHandle(device);
   return 0;
 }
@@ -90,14 +99,14 @@ static int cutorch_getDeviceProperties(lua_State *L)
 
 static int cutorch_seed(lua_State *L)
 {
-  unsigned long seed = THCRandom_seed();
+  unsigned long seed = THCRandom_seed(getState(L)->rngState);
   lua_pushnumber(L, seed);
   return 1;
 }
 
 static int cutorch_initialSeed(lua_State *L)
 {
-  unsigned long seed = THCRandom_initialSeed();
+  unsigned long seed = THCRandom_initialSeed(getState(L)->rngState);
   lua_pushnumber(L, seed);
   return 1;
 }
@@ -105,14 +114,14 @@ static int cutorch_initialSeed(lua_State *L)
 static int cutorch_manualSeed(lua_State *L)
 {
   unsigned long seed = luaL_checknumber(L, 1);
-  THCRandom_manualSeed(seed);
+  THCRandom_manualSeed(getState(L)->rngState, seed);
   return 0;
 }
 
 static int cutorch_getRNGState(lua_State *L)
 {
   THByteTensor* t = THByteTensor_new();
-  THCRandom_getRNGState(t);
+  THCRandom_getRNGState(getState(L)->rngState, t);
   luaT_pushudata(L, t, "torch.ByteTensor");
   return 1;
 }
@@ -120,7 +129,7 @@ static int cutorch_getRNGState(lua_State *L)
 static int cutorch_setRNGState(lua_State *L)
 {
   THByteTensor* t = luaT_checkudata(L, 1, "torch.ByteTensor");
-  THCRandom_setRNGState(t);
+  THCRandom_setRNGState(getState(L)->rngState, t);
   return 0;
 }
 
@@ -146,12 +155,17 @@ int luaopen_libcutorch(lua_State *L)
   lua_newtable(L);
   luaL_register(L, NULL, cutorch_stuff__);
 
-  THCudaInit();
+  THCudaState* state = (THCudaState*)malloc(sizeof(THCudaState));
+  THCudaInit(state);
 
   cutorch_CudaStorage_init(L);
   cutorch_CudaTensor_init(L);
   cutorch_CudaTensorMath_init(L);
   cutorch_CudaTensorOperator_init(L);
+
+  /* Store state in cutorch table. */
+  lua_pushlightuserdata(L, state);
+  lua_setfield(L, -2, "_state");
 
   return 1;
 }

--- a/lib/THC/THCGeneral.h
+++ b/lib/THC/THCGeneral.h
@@ -31,8 +31,16 @@ THC_API void THCudaBlas_init(int num_devices, int current_device);
 THC_API void THCudaBlas_shutdown();
 THC_API void THCudaBlas_setHandle(int device);
 
-THC_API void THCudaInit(void);
-THC_API void THCudaShutdown(void);
+struct THCudaRNGState;  /* Random number generator state. */
+
+/* Global state to be held in the cutorch table. */
+typedef struct THCudaState
+{
+  struct THCudaRNGState* rngState;
+} THCudaState;
+
+THC_API void THCudaInit(THCudaState* state);
+THC_API void THCudaShutdown(THCudaState* state);
 
 #define THCudaCheck(err)    __THCudaCheck(err, __FILE__, __LINE__)
 #define THCublasCheck(err)  __THCublasCheck(err,  __FILE__, __LINE__)

--- a/lib/THC/THCTensorMath.cu
+++ b/lib/THC/THCTensorMath.cu
@@ -1479,16 +1479,16 @@ float THCudaTensor_dist(THCudaTensor *self, THCudaTensor *src, float value)
   return pow(result, (float)1.0/value);
 }
 
-void THCudaTensor_rand(THCudaTensor *r_, THLongStorage *size)
+void THCudaTensor_rand(THCudaRNGState* rng_state, THCudaTensor *r_, THLongStorage *size)
 {
   THCudaTensor_resize(r_, size, NULL);
-  THCudaTensor_uniform(r_, 0, 1);
+  THCudaTensor_uniform(rng_state, r_, 0, 1);
 }
 
-void THCudaTensor_randn(THCudaTensor *r_, THLongStorage *size)
+void THCudaTensor_randn(THCudaRNGState* rng_state, THCudaTensor *r_, THLongStorage *size)
 {
   THCudaTensor_resize(r_, size, NULL);
-  THCudaTensor_normal(r_, 0, 1);
+  THCudaTensor_normal(rng_state, r_, 0, 1);
 }
 
 __global__ void THCudaTensor_kernel_indexFill(

--- a/lib/THC/THCTensorMath.h
+++ b/lib/THC/THCTensorMath.h
@@ -3,6 +3,8 @@
 
 #include "THCTensor.h"
 
+struct THCudaRNGState;
+
 THC_API void THCudaTensor_fill(THCudaTensor *self, float value);
 THC_API void THCudaTensor_zero(THCudaTensor *self);
 
@@ -83,8 +85,8 @@ THC_API void  THCudaTensor_norm(THCudaTensor* self, THCudaTensor* src, float val
 THC_API void  THCudaTensor_renorm(THCudaTensor* self, THCudaTensor* src, float value, long dimension, float max_norm);
 THC_API float THCudaTensor_dist(THCudaTensor *self, THCudaTensor *src, float value);
 
-THC_API void THCudaTensor_rand(THCudaTensor *r_, THLongStorage *size);
-THC_API void THCudaTensor_randn(THCudaTensor *r_, THLongStorage *size);
+THC_API void THCudaTensor_rand(struct THCudaRNGState* rng_state, THCudaTensor *r_, THLongStorage *size);
+THC_API void THCudaTensor_randn(struct THCudaRNGState* rng_state, THCudaTensor *r_, THLongStorage *size);
 
 THC_API void THCudaTensor_indexCopy(THCudaTensor *res_, int dim, THLongTensor *indices, THCudaTensor *src);
 THC_API void THCudaTensor_indexFill(THCudaTensor *tensor, int dim, THLongTensor *index, float val);

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -10,19 +10,6 @@
 #define MAX_NUM_BLOCKS 64
 #define BLOCK_SIZE 256
 
-/* Generator */
-typedef struct _Generator {
-  curandStateMtgp32* gen_states;
-  mtgp32_kernel_params *kernel_params;
-  int initf;
-  unsigned long initial_seed;
-} Generator;
-
-/* One generator per GPU */
-static Generator* gen = NULL;
-static Generator* current_gen = NULL;
-static int num_devices = -1;
-
 /* Sets up generator. Allocates but does not create the generator states. */
 __host__ void initializeGenerator(Generator* gen)
 {
@@ -60,77 +47,76 @@ __host__ void createGeneratorState(Generator* gen, unsigned long seed)
 }
 
 /* Initialize generator array (must be called before any other function) */
-__host__ void THCRandom_init(int devices, int current_device)
+__host__ void THCRandom_init(THCudaRNGState* state, int devices, int current_device)
 {
-  num_devices = devices;
-  if (gen) free(gen);
-  gen = (Generator*)malloc(num_devices * sizeof(Generator));
-  for (int i = 0; i < num_devices; ++i)
+  state->num_devices = devices;
+  state->gen = (Generator*)malloc(state->num_devices * sizeof(Generator));
+  for (int i = 0; i < state->num_devices; ++i)
   {
-    gen[i].initf = 0;
-    gen[i].initial_seed = 0;
-    gen[i].gen_states = NULL;
-    gen[i].kernel_params = NULL;
+    state->gen[i].initf = 0;
+    state->gen[i].initial_seed = 0;
+    state->gen[i].gen_states = NULL;
+    state->gen[i].kernel_params = NULL;
   }
-  current_gen = &gen[current_device];
+  state->current_gen = &state->gen[current_device];
   // Initialize the generator for the current device. Other generators will be
   // initialized on-demand in THCRandom_setGenerator.
-  initializeGenerator(current_gen);
-  THCRandom_seed();
+  initializeGenerator(state->current_gen);
+  THCRandom_seed(state);
 }
 
 /* Destroy generators and free memory */
-__host__ void THCRandom_shutdown()
+__host__ void THCRandom_shutdown(THCudaRNGState* state)
 {
-  if (gen == NULL) return;
-  for (int i = 0; i < num_devices; ++i)
+  if (state->gen == NULL) return;
+  for (int i = 0; i < state->num_devices; ++i)
   {
-    destroyGenerator(&gen[i]);
+    destroyGenerator(&state->gen[i]);
   }
-  free(gen);
-  gen = NULL;
-  current_gen = NULL;
+  free(state->gen);
+  state->gen = NULL;
+  state->current_gen = NULL;
 }
 
 /* Set the generator for the current device */
-__host__ void THCRandom_setGenerator(int device)
+__host__ void THCRandom_setGenerator(THCudaRNGState* state, int device)
 {
-  if (device >= num_devices) THError("Invalid device index.");
-  current_gen = &gen[device];
-  if (current_gen->initf == 0)
+  if (device >= state->num_devices) THError("Invalid device index.");
+  state->current_gen = &state->gen[device];
+  if (state->current_gen->initf == 0)
   {
-    initializeGenerator(current_gen);
-    THCRandom_seed();
+    initializeGenerator(state->current_gen);
+    THCRandom_seed(state);
   }
 }
 
 /* Random seed */
-__host__ unsigned long THCRandom_seed()
+__host__ unsigned long THCRandom_seed(THCudaRNGState* state)
 {
   unsigned long s = (unsigned long)time(0);
-  THCRandom_manualSeed(s);
+  THCRandom_manualSeed(state, s);
   return s;
 }
 
 /* Manually set the seed */
-__host__ void THCRandom_manualSeed(unsigned long seed)
+__host__ void THCRandom_manualSeed(THCudaRNGState* state, unsigned long seed)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
-  current_gen->initial_seed = seed;
-  createGeneratorState(current_gen, seed);
-  current_gen->initf = 1;
+  state->current_gen->initial_seed = seed;
+  createGeneratorState(state->current_gen, seed);
+  state->current_gen->initf = 1;
 }
 
 /* Get the initial seed */
-__host__ unsigned long THCRandom_initialSeed()
+__host__ unsigned long THCRandom_initialSeed(THCudaRNGState* state)
 {
-  return current_gen->initial_seed;
+  return state->current_gen->initial_seed;
 }
 
-__host__ void THCRandom_getRNGState(THByteTensor *rng_state)
+__host__ void THCRandom_getRNGState(THCudaRNGState* state, THByteTensor *rng_state)
 {
   // The RNG state comprises the MTPG32 states and the seed.
   static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
@@ -139,21 +125,21 @@ __host__ void THCRandom_getRNGState(THByteTensor *rng_state)
   THByteTensor_resize1d(rng_state, total_size);
   THArgCheck(THByteTensor_nElement(rng_state) == total_size, 1, "RNG state is wrong size");
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
-  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), current_gen->gen_states,
+  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), state->current_gen->gen_states,
                          states_size, cudaMemcpyDeviceToHost));
-  memcpy(THByteTensor_data(rng_state) + states_size, &current_gen->initial_seed, seed_size);
+  memcpy(THByteTensor_data(rng_state) + states_size, &state->current_gen->initial_seed, seed_size);
 }
 
-__host__ void THCRandom_setRNGState(THByteTensor *rng_state)
+__host__ void THCRandom_setRNGState(THCudaRNGState* state, THByteTensor *rng_state)
 {
   static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
   static const size_t seed_size = sizeof(unsigned long);
   static const size_t total_size = states_size + seed_size;
   THArgCheck(THByteTensor_nElement(rng_state) == total_size, 1, "RNG state is wrong size");
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
-  THCudaCheck(cudaMemcpy(current_gen->gen_states, THByteTensor_data(rng_state),
+  THCudaCheck(cudaMemcpy(state->current_gen->gen_states, THByteTensor_data(rng_state),
                          states_size, cudaMemcpyHostToDevice));
-  memcpy(&current_gen->initial_seed, THByteTensor_data(rng_state) + states_size, seed_size);
+  memcpy(&state->current_gen->initial_seed, THByteTensor_data(rng_state) + states_size, seed_size);
 }
 
 #define GENERATE_KERNEL1(NAME, ARG1, CURAND_FUNC, TRANSFORM)                   \
@@ -198,9 +184,9 @@ __global__ void generate_log_normal(curandStateMtgp32 *state, int size, float *r
 }
 
 #define NUM_BLOCKS min((int)DIVUP(size, BLOCK_SIZE), MAX_NUM_BLOCKS)
-THC_API void THCudaTensor_uniform(THCudaTensor *self_, double a, double b)
+THC_API void THCudaTensor_uniform(THCudaRNGState* state, THCudaTensor *self_, double a, double b)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -209,14 +195,14 @@ THC_API void THCudaTensor_uniform(THCudaTensor *self_, double a, double b)
   float *data = THCudaTensor_data(self);
 
   generate_uniform<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, a, b);
+      state->current_gen->gen_states, size, data, a, b);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_bernoulli(THCudaTensor *self_, double p)
+THC_API void THCudaTensor_bernoulli(THCudaRNGState* state, THCudaTensor *self_, double p)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -225,14 +211,14 @@ THC_API void THCudaTensor_bernoulli(THCudaTensor *self_, double p)
   float *data = THCudaTensor_data(self);
 
   generate_bernoulli<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, p);
+      state->current_gen->gen_states, size, data, p);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_normal(THCudaTensor *self_, double mean, double stdv)
+THC_API void THCudaTensor_normal(THCudaRNGState* state, THCudaTensor *self_, double mean, double stdv)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -241,14 +227,14 @@ THC_API void THCudaTensor_normal(THCudaTensor *self_, double mean, double stdv)
   float *data = THCudaTensor_data(self);
 
   generate_normal<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, mean, stdv);
+      state->current_gen->gen_states, size, data, mean, stdv);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_logNormal(THCudaTensor *self_, double mean, double stdv)
+THC_API void THCudaTensor_logNormal(THCudaRNGState* state, THCudaTensor *self_, double mean, double stdv)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -257,14 +243,14 @@ THC_API void THCudaTensor_logNormal(THCudaTensor *self_, double mean, double std
   float *data = THCudaTensor_data(self);
 
   generate_log_normal<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, mean, stdv);
+      state->current_gen->gen_states, size, data, mean, stdv);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_geometric(THCudaTensor *self_, double p)
+THC_API void THCudaTensor_geometric(THCudaRNGState* state, THCudaTensor *self_, double p)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -273,14 +259,14 @@ THC_API void THCudaTensor_geometric(THCudaTensor *self_, double p)
   float *data = THCudaTensor_data(self);
 
   generate_geometric<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, p);
+      state->current_gen->gen_states, size, data, p);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_exponential(THCudaTensor *self_, double lambda)
+THC_API void THCudaTensor_exponential(THCudaRNGState* state, THCudaTensor *self_, double lambda)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -289,14 +275,14 @@ THC_API void THCudaTensor_exponential(THCudaTensor *self_, double lambda)
   float *data = THCudaTensor_data(self);
 
   generate_exponential<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, lambda);
+      state->current_gen->gen_states, size, data, lambda);
 
   THCudaTensor_freeCopyTo(self, self_);
 };
 
-THC_API void THCudaTensor_cauchy(THCudaTensor *self_, double median, double sigma)
+THC_API void THCudaTensor_cauchy(THCudaRNGState* state, THCudaTensor *self_, double median, double sigma)
 {
-  if (current_gen == NULL)
+  if (state->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
   }
@@ -305,7 +291,7 @@ THC_API void THCudaTensor_cauchy(THCudaTensor *self_, double median, double sigm
   float *data = THCudaTensor_data(self);
 
   generate_cauchy<<<NUM_BLOCKS, BLOCK_SIZE>>>(
-      current_gen->gen_states, size, data, median, sigma);
+      state->current_gen->gen_states, size, data, median, sigma);
 
   THCudaTensor_freeCopyTo(self, self_);
 };

--- a/lib/THC/THCTensorRandom.h
+++ b/lib/THC/THCTensorRandom.h
@@ -3,20 +3,35 @@
 
 #include "THCTensor.h"
 
-THC_API void THCRandom_init(int num_devices, int current_device);
-THC_API void THCRandom_shutdown();
-THC_API void THCRandom_setGenerator(int device);
-THC_API unsigned long THCRandom_seed();
-THC_API void THCRandom_manualSeed(unsigned long the_seed_);
-THC_API unsigned long THCRandom_initialSeed();
-THC_API void THCRandom_getRNGState(THByteTensor *rng_state);
-THC_API void THCRandom_setRNGState(THByteTensor *rng_state);
-THC_API void THCudaTensor_geometric(THCudaTensor *self, double p);
-THC_API void THCudaTensor_bernoulli(THCudaTensor *self, double p);
-THC_API void THCudaTensor_uniform(THCudaTensor *self, double a, double b);
-THC_API void THCudaTensor_normal(THCudaTensor *self, double mean, double stdv);
-THC_API void THCudaTensor_exponential(THCudaTensor *self, double lambda);
-THC_API void THCudaTensor_cauchy(THCudaTensor *self, double median, double sigma);
-THC_API void THCudaTensor_logNormal(THCudaTensor *self, double mean, double stdv);
+/* Generator */
+typedef struct _Generator {
+  struct curandStateMtgp32* gen_states;
+  struct mtgp32_kernel_params *kernel_params;
+  int initf;
+  unsigned long initial_seed;
+} Generator;
+
+typedef struct THCudaRNGState {
+  /* One generator per GPU */
+  Generator* gen;
+  Generator* current_gen;
+  int num_devices;
+} THCudaRNGState;
+
+THC_API void THCRandom_init(THCudaRNGState* state, int num_devices, int current_device);
+THC_API void THCRandom_shutdown(THCudaRNGState* state);
+THC_API void THCRandom_setGenerator(THCudaRNGState* state, int device);
+THC_API unsigned long THCRandom_seed(THCudaRNGState* state);
+THC_API void THCRandom_manualSeed(THCudaRNGState* state, unsigned long the_seed_);
+THC_API unsigned long THCRandom_initialSeed(THCudaRNGState* state);
+THC_API void THCRandom_getRNGState(THCudaRNGState* state, THByteTensor *rng_state);
+THC_API void THCRandom_setRNGState(THCudaRNGState* state, THByteTensor *rng_state);
+THC_API void THCudaTensor_geometric(THCudaRNGState* state, THCudaTensor *self, double p);
+THC_API void THCudaTensor_bernoulli(THCudaRNGState* state, THCudaTensor *self, double p);
+THC_API void THCudaTensor_uniform(THCudaRNGState* state, THCudaTensor *self, double a, double b);
+THC_API void THCudaTensor_normal(THCudaRNGState* state, THCudaTensor *self, double mean, double stdv);
+THC_API void THCudaTensor_exponential(THCudaRNGState* state, THCudaTensor *self, double lambda);
+THC_API void THCudaTensor_cauchy(THCudaRNGState* state, THCudaTensor *self, double median, double sigma);
+THC_API void THCudaTensor_logNormal(THCudaRNGState* state, THCudaTensor *self, double mean, double stdv);
 
 #endif


### PR DESCRIPTION
Create a new struct for cutorch's global state, `THCudaState`, currently
only containing the global RNG state, `THCudaRNGState`.
All RNG methods take the state as their first argument.
