### PR TITLE
adding getDevice for tensor, manualSeedAll and seedAll

### DIFF
--- a/Tensor.c
+++ b/Tensor.c
@@ -159,6 +159,12 @@ static int cuda_FloatTensor_fakecopy(lua_State *L)
   return 1;
 }
 
+static int cutorch_CudaTensor_getDevice(lua_State *L) {
+  THCudaTensor *tensor = luaT_checkudata(L, 1, "torch.CudaTensor");
+  lua_pushinteger(L, THCudaTensor_getDevice(tensor) + 1);
+  return 1;
+}
+
 void cutorch_CudaTensor_init(lua_State* L)
 {
   /* the standard stuff */
@@ -200,4 +206,10 @@ void cutorch_CudaTensor_init(lua_State* L)
       lua_pop(L, 1);
     }
   }
+
+  luaT_pushmetatable(L, "torch.CudaTensor");
+  lua_pushcfunction(L, cutorch_CudaTensor_getDevice);
+  lua_setfield(L, -2, "getDevice");
+
+  lua_pop(L, 1);
 }

--- a/init.c
+++ b/init.c
@@ -104,6 +104,13 @@ static int cutorch_seed(lua_State *L)
   return 1;
 }
 
+static int cutorch_seedAll(lua_State *L)
+{
+  unsigned long seed = THCRandom_seedAll(getState(L)->rngState);
+  lua_pushnumber(L, seed);
+  return 1;
+}
+
 static int cutorch_initialSeed(lua_State *L)
 {
   unsigned long seed = THCRandom_initialSeed(getState(L)->rngState);
@@ -115,6 +122,13 @@ static int cutorch_manualSeed(lua_State *L)
 {
   unsigned long seed = luaL_checknumber(L, 1);
   THCRandom_manualSeed(getState(L)->rngState, seed);
+  return 0;
+}
+
+static int cutorch_manualSeedAll(lua_State* L)
+{
+  unsigned long seed = luaL_checknumber(L, 1);
+  THCRandom_manualSeedAll(getState(L)->rngState, seed);
   return 0;
 }
 
@@ -141,8 +155,10 @@ static const struct luaL_Reg cutorch_stuff__ [] = {
   {"getDeviceProperties", cutorch_getDeviceProperties},
   {"setDevice", cutorch_setDevice},
   {"seed", cutorch_seed},
+  {"seedAll", cutorch_seedAll},
   {"initialSeed", cutorch_initialSeed},
   {"manualSeed", cutorch_manualSeed},
+  {"manualSeedAll", cutorch_manualSeedAll},
   {"getRNGState", cutorch_getRNGState},
   {"setRNGState", cutorch_setRNGState},
   {NULL, NULL}

--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -65,7 +65,7 @@ void __THCublasCheck(cublasStatus_t status, const char *file, const int line)
         break;
 
       case CUBLAS_STATUS_ALLOC_FAILED:
-        errmsg = "ressource allocation failed";
+        errmsg = "resource allocation failed";
         break;
 
       case CUBLAS_STATUS_INVALID_VALUE:
@@ -128,4 +128,3 @@ void THCudaGetGridSize(int *nBlockPerColumn_, int *nBlockPerRow_, int *nThreadPe
   *nBlockPerRow_ = (int)nBlockPerRow;
   *nThreadPerBlock_ = (int)nThreadPerBlock;
 }
-

--- a/lib/THC/THCGeneral.h
+++ b/lib/THC/THCGeneral.h
@@ -5,6 +5,7 @@
 #undef log1p
 
 #include "cuda.h"
+#include "cuda_runtime.h"
 #include "cublas_v2.h"
 
 #ifdef __cplusplus
@@ -42,7 +43,7 @@ typedef struct THCudaState
 THC_API void THCudaInit(THCudaState* state);
 THC_API void THCudaShutdown(THCudaState* state);
 
-#define THCudaCheck(err)    __THCudaCheck(err, __FILE__, __LINE__)
+#define THCudaCheck(err)  __THCudaCheck(err, __FILE__, __LINE__)
 #define THCublasCheck(err)  __THCublasCheck(err,  __FILE__, __LINE__)
 
 THC_API void __THCudaCheck(cudaError_t err, const char *file, const int line);

--- a/lib/THC/THCTensor.cu
+++ b/lib/THC/THCTensor.cu
@@ -24,3 +24,10 @@ cudaTextureObject_t THCudaTensor_getTextureObject(THCudaTensor *self)
   }
   return texObj;
 }
+
+THC_API int THCudaTensor_getDevice(const THCudaTensor* thc) {
+  if (!thc->storage) return -1;
+  cudaPointerAttributes attr;
+  THCudaCheck(cudaPointerGetAttributes(&attr, thc->storage->data));
+  return attr.device;
+}

--- a/lib/THC/THCTensor.h
+++ b/lib/THC/THCTensor.h
@@ -29,6 +29,7 @@
 THC_API void THCudaTensor_fill(THCudaTensor *self, float value);
 THC_API void THCudaTensor_copy(THCudaTensor *self, THCudaTensor *src);
 THC_API cudaTextureObject_t THCudaTensor_getTextureObject(THCudaTensor *self);
+THC_API int THCudaTensor_getDevice(const THCudaTensor *self);
 
 THC_API void THByteTensor_copyCuda(THByteTensor *self, THCudaTensor *src);
 THC_API void THCharTensor_copyCuda(THCharTensor *self, THCudaTensor *src);

--- a/lib/THC/THCTensorConv.cu
+++ b/lib/THC/THCTensorConv.cu
@@ -325,12 +325,7 @@ THC_API void THCudaTensor_conv2Dmv(THCudaTensor *output, float beta, THCudaTenso
     nOutputCols = (nInputCols - 1) * scol + nKernelCols;
 
     // use temp buffer
-    static THCudaTensor *inputP;
-    static int firstcall = 1;
-    if (firstcall) {
-      inputP = THCudaTensor_new();
-      firstcall = 0;
-    }
+    THCudaTensor *inputP = THCudaTensor_new();
 
     // create a zero-padded input
     long nInputRowsPadded = (nOutputRows - 1) * srow + nKernelRows;
@@ -450,12 +445,7 @@ THC_API void THCudaTensor_conv2Dmm(THCudaTensor *output, float beta, THCudaTenso
     nOutputCols = (nInputCols - 1) * scol + nKernelCols;
 
     // use temp buffer
-    static THCudaTensor *inputP;
-    static int firstcall = 1;
-    if (firstcall) {
-      inputP = THCudaTensor_new();
-      firstcall = 0;
-    }
+    THCudaTensor *inputP = THCudaTensor_new();
 
     // create a zero-padded input
     long nInputRowsPadded = (nOutputRows - 1) * srow + nKernelRows;

--- a/lib/THC/THCTensorMath.cu
+++ b/lib/THC/THCTensorMath.cu
@@ -23,7 +23,7 @@ void THCudaTensor_fill(THCudaTensor *self_, float value)
 void THCudaTensor_zero(THCudaTensor *self_)
 {
   THCudaTensor *self = THCudaTensor_newContiguous(self_);
-  cudaMemset(THCudaTensor_data(self), 0, sizeof(float)*THCudaTensor_nElement(self));
+  THCudaCheck(cudaMemset(THCudaTensor_data(self), 0, sizeof(float)*THCudaTensor_nElement(self)));
   THCudaTensor_freeCopyTo(self, self_);
 }
 
@@ -1380,7 +1380,7 @@ float THCudaTensor_normall(THCudaTensor *self, float value)
 
 void THCudaTensor_norm(THCudaTensor* self, THCudaTensor* src, float value, long dimension)
 {
-  if(value == 0.0f) {
+  if (value == 0.0f) {
     THCudaTensor_transformReduceDim(self, src, dimension, partial_not_equal_functor(0.0f), (float)0, thrust::plus<float>());
   } else {
     THCudaTensor_transformReduceDim(self, src, dimension, norm_functor(value), (float)0, thrust::plus<float>());

--- a/lib/THC/THCTensorRandom.h
+++ b/lib/THC/THCTensorRandom.h
@@ -22,7 +22,9 @@ THC_API void THCRandom_init(THCudaRNGState* state, int num_devices, int current_
 THC_API void THCRandom_shutdown(THCudaRNGState* state);
 THC_API void THCRandom_setGenerator(THCudaRNGState* state, int device);
 THC_API unsigned long THCRandom_seed(THCudaRNGState* state);
+THC_API unsigned long THCRandom_seedAll(THCudaRNGState* state);
 THC_API void THCRandom_manualSeed(THCudaRNGState* state, unsigned long the_seed_);
+THC_API void THCRandom_manualSeedAll(THCudaRNGState* state, unsigned long the_seed_);
 THC_API unsigned long THCRandom_initialSeed(THCudaRNGState* state);
 THC_API void THCRandom_getRNGState(THCudaRNGState* state, THByteTensor *rng_state);
 THC_API void THCRandom_setRNGState(THCudaRNGState* state, THByteTensor *rng_state);


### PR DESCRIPTION
- Adds a function on a CudaTensor:getDevice() that would give you which GPU the tensor lives on.
- Adds a manualSeedAll and seedAll for situations when you want all GPUs to have the same seed.
- removes static variables in TensorConv, which were unnecessary and ugly.
