### PR TITLE
Reset RNG state after device reset.

### DIFF
--- a/init.c
+++ b/init.c
@@ -7,6 +7,15 @@ extern void cutorch_CudaTensor_init(lua_State* L);
 extern void cutorch_CudaTensorMath_init(lua_State* L);
 extern void cutorch_CudaTensorOperator_init(lua_State* L);
 
+static THCudaState* getState(lua_State *L)
+{
+  lua_getglobal(L, "cutorch");
+  lua_getfield(L, -1, "_state");
+  THCudaState *state = lua_touserdata(L, -1);
+  lua_pop(L, 2);
+  return state;
+}
+
 static int cutorch_synchronize(lua_State *L)
 {
   cudaDeviceSynchronize();
@@ -25,6 +34,7 @@ static int cutorch_getDevice(lua_State *L)
 static int cutorch_deviceReset(lua_State *L)
 {
   THCudaCheck(cudaDeviceReset());
+  THCRandom_resetGenerator(getState(L)->rngState);
   return 0;
 }
 
@@ -34,15 +44,6 @@ static int cutorch_getDeviceCount(lua_State *L)
   THCudaCheck(cudaGetDeviceCount(&ndevice));
   lua_pushnumber(L, ndevice);
   return 1;
-}
-
-static THCudaState* getState(lua_State *L)
-{
-  lua_getglobal(L, "cutorch");
-  lua_getfield(L, -1, "_state");
-  THCudaState *state = lua_touserdata(L, -1);
-  lua_pop(L, 2);
-  return state;
 }
 
 static int cutorch_setDevice(lua_State *L)

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -94,6 +94,13 @@ __host__ void THCRandom_setGenerator(THCudaRNGState* state, int device)
   }
 }
 
+/* Reset the generator for the current device after a device reset */
+__host__ void THCRandom_resetGenerator(THCudaRNGState* state)
+{
+  initializeGenerator(state->current_gen);
+  THCRandom_manualSeed(state, state->current_gen->initial_seed);
+}
+
 /* Random seed */
 __host__ unsigned long THCRandom_seed(THCudaRNGState* state)
 {

--- a/lib/THC/THCTensorRandom.h
+++ b/lib/THC/THCTensorRandom.h
@@ -21,6 +21,7 @@ typedef struct THCudaRNGState {
 THC_API void THCRandom_init(THCudaRNGState* state, int num_devices, int current_device);
 THC_API void THCRandom_shutdown(THCudaRNGState* state);
 THC_API void THCRandom_setGenerator(THCudaRNGState* state, int device);
+THC_API void THCRandom_resetGenerator(THCudaRNGState* state);
 THC_API unsigned long THCRandom_seed(THCudaRNGState* state);
 THC_API unsigned long THCRandom_seedAll(THCudaRNGState* state);
 THC_API void THCRandom_manualSeed(THCudaRNGState* state, unsigned long the_seed_);

--- a/test/test.lua
+++ b/test/test.lua
@@ -915,6 +915,24 @@ function test.get_device()
     end
 end
 
+function test.reset_device()
+   local sz = math.floor(torch.uniform(minsize,maxsize))
+
+   cutorch.manualSeed(2384)
+   local t = torch.CudaTensor(sz):normal()
+
+   -- Create a CPU copy and destroy the GPU tensor because the GPU pointer will be invalidated by the reset.
+   local tf = t:float()
+   t = nil
+   collectgarbage()
+
+   -- After a device reset, the RNG state should have been reset to its initial state.
+   cutorch.deviceReset()
+   local u = torch.CudaTensor(sz):normal()
+
+   tester:assertTensorEq(tf, u:float(), 1e-6, "values not equal after restoring the RNG state")
+end
+
 function cutorch.test(tests)
    math.randomseed(os.time())
    torch.manualSeed(os.time())


### PR DESCRIPTION
A device reset destroys the state of the RNG, so we have to re-initialize
it after each reset.
