### PR TITLE
Add missing headers.

### DIFF
--- a/lib/THC/THCTensorConv.cu
+++ b/lib/THC/THCTensorConv.cu
@@ -1,4 +1,5 @@
 #include "THCTensorConv.h"
+#include "THCTensorMath.h"
 #include "THCGeneral.h"
 #include <stdio.h>
 

--- a/lib/THC/THCTensorMath.cu
+++ b/lib/THC/THCTensorMath.cu
@@ -3,6 +3,7 @@
 #include "THCBlas.h"
 #include "THCTensorRandom.h"
 
+#include <thrust/device_ptr.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/reduce.h>


### PR DESCRIPTION
After adding these headers it's actually possible to compile the .cu
files separately rather than in one monolithic THC.cu. "luarocks make"
takes longer doing that tough (any ideas why?) so maybe it's not worth
doing.

There's also a comment in THC.cu saying that thrust doesn't allow multiple
files. I had no problems compiling it on my Linux machine with CUDA 5.5 though.
