### PR TITLE
Supporting functions for Complex Convolutions

### DIFF
--- a/lib/THC/THCBlas.cu
+++ b/lib/THC/THCBlas.cu
@@ -165,6 +165,35 @@ void THCudaBlas_gemv(char trans, long m, long n, float alpha, float *a, long lda
           "in the range 0 < [val] <= %d", INT_MAX);
 }
 
+void THCudaBlas_cgemv(char trans, long m, long n, cuComplex alpha, cuComplex *a, long lda, cuComplex *x, long incx, cuComplex beta, cuComplex *y, long incy)
+{   
+  if(n == 1)
+    lda = m;
+
+  cublasOperation_t op;
+  if (trans == 't') op = CUBLAS_OP_T;
+  else if (trans == 'n') op = CUBLAS_OP_N;
+  else if (trans == 'c') op = CUBLAS_OP_C;
+
+  if( (m <= INT_MAX) && (n <= INT_MAX) &&
+      (lda > 0) && (lda <= INT_MAX) &&
+      (incx > 0) && (incx <= INT_MAX) &&
+      (incy > 0) && (incy <= INT_MAX) )
+  {
+    int i_m = (int)m;
+    int i_n = (int)n;
+    int i_lda = (int)lda;
+    int i_incx = (int)incx;
+    int i_incy = (int)incy;
+
+    THCublasCheck(cublasCgemv(*current_handle, op, i_m, i_n, &alpha, a, i_lda, x, i_incx, &beta, y, i_incy));
+    return;
+  }
+  THError("Cublas_cgemv only supports m, n, lda, incx, incy"
+          "in the range 0 < [val] <= %d", INT_MAX);
+}
+
+
 void THCudaBlas_ger(long m, long n, float alpha, float *x, long incx, float *y, long incy, float *a, long lda)
 {
   if(n == 1)
@@ -241,5 +270,63 @@ void THCudaBlas_gemm(char transa, char transb, long m, long n, long k, float alp
     return;
   }
   THError("Cublas_gemm only supports m, n, k, lda, ldb, ldc"
+          "with the bound [val] <= %d", INT_MAX);
+}
+
+void THCudaBlas_cgemm(char transa, char transb, long m, long n, long k, cuComplex alpha, cuComplex *a, long lda, cuComplex *b, long ldb, cuComplex beta, cuComplex *c, long ldc)
+{
+  int transa_ = ((transa == 't') || (transa == 'T'));
+  int transb_ = ((transb == 't') || (transb == 'T'));
+
+  if(n == 1)
+    ldc = m;
+
+  if(transa_)
+  {
+    if(m == 1)
+      lda = k;
+  }
+  else
+  {
+    if(k == 1)
+      lda = m;
+  }
+
+  if(transb_)
+  {
+    if(k == 1)
+      ldb = n;
+  }
+  else
+  {
+    if(n == 1)
+      ldb = k;
+  }
+
+  cublasOperation_t opa;
+  if (transa == 't') opa = CUBLAS_OP_T;
+  else if (transa == 'n') opa = CUBLAS_OP_N;
+  else if (transa == 'c') opa = CUBLAS_OP_C;
+  else THError("transa must be one of: t, n, c");
+
+  cublasOperation_t opb;
+  if (transb == 't') opb = CUBLAS_OP_T;
+  else if (transb == 'n') opb = CUBLAS_OP_N;
+  else if (transb == 'c') opb = CUBLAS_OP_C;
+  else THError("transb must be one of: t, n, c");
+
+  if( (m <= INT_MAX) && (n <= INT_MAX) && (k <= INT_MAX) && (lda <= INT_MAX)  && (ldb <= INT_MAX) && (ldc <= INT_MAX) )
+  {
+    int i_m = (int)m;
+    int i_n = (int)n;
+    int i_k = (int)k;
+    int i_lda = (int)lda;
+    int i_ldb = (int)ldb;
+    int i_ldc = (int)ldc;
+
+    THCublasCheck(cublasCgemm(*current_handle, opa, opb, i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb, &beta, c, i_ldc));
+    return;
+  }
+  THError("Cublas_cgemm only supports m, n, k, lda, ldb, ldc"
           "with the bound [val] <= %d", INT_MAX);
 }

--- a/lib/THC/THCBlas.h
+++ b/lib/THC/THCBlas.h
@@ -13,6 +13,10 @@
 #include "generic/THBlas.h"
 #undef TH_GENERIC_FILE
 
+TH_API void THCudaBlas_cgemm(char transa, char transb, long m, long n, long k, cuComplex alpha, cuComplex *a, long lda, cuComplex *b, long ldb, cuComplex beta, cuComplex *c, long ldc);
+
+TH_API void THCudaBlas_cgemv(char trans, long m, long n, cuComplex alpha, cuComplex *a, long lda, cuComplex *x, long incx, cuComplex beta, cuComplex *y, long incy);
+
 #undef THBlas_
 #undef real
 #undef Real


### PR DESCRIPTION
added cgemv and cgemm methods.

Note: I didn't want to add a cgemv and cgemm CPU implementation (in the torch repo) because I saw no easy way to add complex number support on the CPU side (without a huge amount of work).  Likewise, I don't need it and I'm super busy, so I didn't have time to implement it.  So instead I've just added 2 extra methods to the THCBlas.h header...  I don't "love" that I added extra methods into the header (since the header is autogenerated from the CPU counterpart), but hopefully code reviewers aren't going to be too offended.

The alternative (that Soumith pointed out to me), would be to add these methods to SpatialConvolutionComplexMM.cu and keep them out of THCBlas.  Personally, I think the should go here because someone might want them later down the line.