### PR TITLE
adds a withDevice closure to easily run code on a given device

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -8,4 +8,15 @@ include('Tensor.lua')
 include('FFI.lua')
 include('test.lua')
 
+function cutorch.withDevice(newDeviceID, closure)
+    local curDeviceID = cutorch.getDevice()
+    cutorch.setDevice(newDeviceID)
+    local vals = {pcall(closure)}
+    cutorch.setDevice(curDeviceID)
+    if vals[1] then
+        return unpack(vals, 2)
+    end
+    error(unpack(vals, 2))
+end
+
 return cutorch


### PR DESCRIPTION
this PR introduces a function cutorch.withDevice, which takes a device ID and a closure.
it makes sure that the closure gets executed on the given device, while restoring your original device after execution.

It is a very useful function for writing multi-GPU code and is heavily used in Facebook's open-source releases.

Merging this cause of a time-crunch (and it is well tested for several months), but feel free to comment.