### PR TITLE
bugfix for pow and tpow for non-inplace operations

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -477,13 +477,13 @@ wrap("atan2",
 
 wrap("pow",
      cname("pow"),
-     {{name=Tensor, returned=true, method={default='nil'}},
-      {name=Tensor, default=1},
+     {{name=Tensor, default=true, returned=true, method={default='nil'}},
+      {name=Tensor, method={default=1}},
       {name=real}},
      cname("tpow"),
-     {{name=Tensor, returned=true, method={default='nil'}},
+     {{name=Tensor, default=true, returned=true, method={default='nil'}},
       {name = real},
-      {name=Tensor, default=1}})
+      {name=Tensor, method={default=1}}})
 
 wrap("rand",
      cname("rand"),


### PR DESCRIPTION
Same problem as https://github.com/torch/cutorch/issues/110 but for pow and tpow.