### PR TITLE
Ignore cudaErrorPeerAccessAlreadyEnabled.

### DIFF
--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -27,8 +27,11 @@ void THCudaInit(THCState* state)
       {
         int can = 0;
         THCudaCheck(cudaDeviceCanAccessPeer(&can, i, j));
-        if(can)
-          THCudaCheck(cudaDeviceEnablePeerAccess(j, 0));
+        if(can) {
+          cudaError_t err = cudaDeviceEnablePeerAccess(j, 0);
+          if (err == cudaErrorPeerAccessAlreadyEnabled) continue;
+          THCudaCheck(err);
+        }
       }
     }
   }


### PR DESCRIPTION
If we call cudaDeviceEnablePeerAccess for the same devices twice, it
will return cudaErrorPeerAccessAlreadyEnabled. THCudaCheck treats that
as an error and fails, whereas it really only indicates that peer access
has already been enabled. In which case we shouldn't fail.