### PR TITLE
Recreate cuBLAS handle on deviceReset.

### DIFF
--- a/init.c
+++ b/init.c
@@ -25,8 +25,10 @@ static int cutorch_getDevice(lua_State *L)
 
 static int cutorch_deviceReset(lua_State *L)
 {
+  THCState *state = cutorch_getstate(L);
   THCudaCheck(cudaDeviceReset());
-  THCRandom_resetGenerator(cutorch_getstate(L));
+  THCudaBlas_reset(state);
+  THCRandom_resetGenerator(state);
   return 0;
 }
 

--- a/lib/THC/THCBlas.cu
+++ b/lib/THC/THCBlas.cu
@@ -28,6 +28,11 @@ void THCudaBlas_shutdown(THCState *state)
   free(blas_state->handles);
 }
 
+void THCudaBlas_reset(THCState *state)
+{
+  cublasCreate(state->blasState->current_handle);
+}
+
 void THCudaBlas_setHandle(THCState *state, int device)
 {
   THCBlasState *blas_state = state->blasState;

--- a/lib/THC/THCGeneral.h
+++ b/lib/THC/THCGeneral.h
@@ -36,6 +36,7 @@ typedef struct THCState
 
 THC_API void THCudaBlas_init(THCState *state, int num_devices, int current_device);
 THC_API void THCudaBlas_shutdown(THCState *state);
+THC_API void THCudaBlas_reset(THCState *state);
 THC_API void THCudaBlas_setHandle(THCState *state, int device);
 
 THC_API void THCudaInit(THCState* state);


### PR DESCRIPTION
Only need to reset the cuBLAS handle for the current device, because
only resources associated with the current device will be reset by
cudaDeviceReset.