### PR TITLE
Tensor.lua: return `self` on `apply`

### DIFF
--- a/Tensor.lua
+++ b/Tensor.lua
@@ -2,6 +2,7 @@ function torch.CudaTensor.apply(self, func)
    local x = torch.FloatTensor(self:size()):copy(self)
    x:apply(func)
    self:copy(x)
+   return self
 end
 
 local function Tensor__type(self,type)


### PR DESCRIPTION
To comply with non-CUDA `apply` version (see [here](https://github.com/torch/torch7/blob/ee03a0a/doc/tensor.md#self-applyfunction)).