### PR TITLE
Fixing call to cudaMemGetInfo to use the correct device.

### DIFF
--- a/init.c
+++ b/init.c
@@ -551,9 +551,14 @@ static int cutorch_setDevice(lua_State *L)
 
 static int cutorch_getDeviceProperties(lua_State *L)
 {
-  struct cudaDeviceProp prop;
   int device = (int)luaL_checknumber(L, 1)-1;
 
+  // switch context to given device so the call to cudaMemGetInfo is for the correct device
+  int oldDevice;
+  THCudaCheck(cudaGetDevice(&oldDevice));
+  THCudaCheck(cudaSetDevice(device));
+
+  struct cudaDeviceProp prop;
   THCudaCheck(cudaGetDeviceProperties(&prop, device));
   lua_newtable(L);
   SET_DEVN_PROP(canMapHostMemory);
@@ -586,6 +591,9 @@ static int cutorch_getDeviceProperties(lua_State *L)
 
   lua_pushstring(L, prop.name);
   lua_setfield(L, -2, "name");
+
+  // restore context
+  THCudaCheck(cudaSetDevice(oldDevice));
 
   return 1;
 }


### PR DESCRIPTION
The function cudaMemGetInfo works on the currently set device, but this function allows an arbitrary device to be passed in. See:

http://developer.download.nvidia.com/compute/cuda/4_1/rel/toolkit/docs/online/group__CUDART__MEMORY_gd5d6772f4b2f3355078ecd6059e6aa74.html

