### PR TITLE
Set exit code to 1 if tests failed.

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -2063,5 +2063,6 @@ end
 
 if runtests then
    cutorch.test()
+   os.exit(#tester.errors == 0 and 0 or 1)
 end
 return test


### PR DESCRIPTION
This is convenient for e.g. continuous integration.