### PR TITLE
Allow CudaTensors as indices

### DIFF
--- a/lib/THC/THCTensorMath.h
+++ b/lib/THC/THCTensorMath.h
@@ -95,9 +95,13 @@ THC_API float THCudaTensor_dist(THCState *state, THCudaTensor *self, THCudaTenso
 THC_API void THCudaTensor_rand(THCState *state, THCudaTensor *r_, THLongStorage *size);
 THC_API void THCudaTensor_randn(THCState *state, THCudaTensor *r_, THLongStorage *size);
 
-THC_API void THCudaTensor_indexCopy(THCState *state, THCudaTensor *res_, int dim, THLongTensor *indices, THCudaTensor *src);
-THC_API void THCudaTensor_indexFill(THCState *state, THCudaTensor *tensor, int dim, THLongTensor *index, float val);
-THC_API void THCudaTensor_indexSelect(THCState *state, THCudaTensor *tensor, THCudaTensor *src, int dim, THLongTensor *index);
+THC_API void THCudaTensor_indexCopy(THCState *state, THCudaTensor *res_, int dim, THCudaTensor *indices, THCudaTensor *src);
+THC_API void THCudaTensor_indexFill(THCState *state, THCudaTensor *tensor, int dim, THCudaTensor *index, float val);
+THC_API void THCudaTensor_indexSelect(THCState *state, THCudaTensor *tensor, THCudaTensor *src, int dim, THCudaTensor *index);
+
+THC_API void THCudaTensor_indexCopy_long(THCState *state, THCudaTensor *res_, int dim, THLongTensor *indices, THCudaTensor *src);
+THC_API void THCudaTensor_indexFill_long(THCState *state, THCudaTensor *tensor, int dim, THLongTensor *index, float val);
+THC_API void THCudaTensor_indexSelect_long(THCState *state, THCudaTensor *tensor, THCudaTensor *src, int dim, THLongTensor *index);
 
 THC_API void THCudaTensor_maskedFill(THCState *state, THCudaTensor *tensor, THCudaTensor *mask, float value);
 THC_API void THCudaTensor_maskedCopy(THCState *state, THCudaTensor *tensor, THCudaTensor *mask, THCudaTensor *src);

--- a/test/test.lua
+++ b/test/test.lua
@@ -905,6 +905,9 @@ function test.index()
    longIndex = torch.randperm(sz3):long()
    compareFloatAndCuda(x, 'index', index, longIndex)
 
+   tester:assert(isEqual(x:cuda():index(index, longIndex:cuda()), x:index(index, longIndex)),
+      "Divergent results between CPU and CUDA for function 'index'")
+
    checkMultiDevice(x, 'index', index, longIndex)
 end
 
@@ -918,21 +921,26 @@ function test.indexCopy()
    -- choose two indices from the first dimension, i.e. [1,sz1]
    local longIndex = torch.LongTensor{math.floor(torch.uniform(1, sz1)), math.floor(torch.uniform(1, sz1))}
    local index = 1
-   local src = torch.Tensor(2, sz2):uniform()
+   local src = torch.FloatTensor(2, sz2):uniform()
    compareFloatAndCudaTensorArgs(x, 'indexCopy', index, longIndex, src)
 
    -- Case 2: 2D tensor, indexCopy over second dimension, 2 indices
    index = 2
    longIndex =  torch.LongTensor{math.floor(torch.uniform(1, sz2)), math.floor(torch.uniform(1, sz2))}
-   src = torch.Tensor(sz1, 2):uniform():cuda()
+   src = torch.FloatTensor(sz1, 2):uniform():cuda()
    compareFloatAndCudaTensorArgs(x, 'indexCopy', index, longIndex, src)
 
    -- Case 3: 1D tensor, indexCopy over 1st dimension, 2 indices
    x = torch.FloatTensor():rand(sz1)
    index = 1
    longIndex = torch.LongTensor{math.floor(torch.uniform(1, sz1)), math.floor(torch.uniform(1, sz1))}
-   src = torch.Tensor(2):uniform()
+   src = torch.FloatTensor(2):uniform()
    compareFloatAndCudaTensorArgs(x, 'indexCopy', index, longIndex, src)
+
+   tester:assert(isEqual(
+      x:cuda():indexCopy(index, longIndex:cuda(), src:cuda()),
+      x:indexCopy(index, longIndex, src)),
+      "Divergent results between CPU and CUDA for function 'indexCopy'")
 
    checkMultiDevice(x, 'indexCopy', index, longIndex, src)
 end
@@ -957,6 +965,11 @@ function test.indexFill()
    longIndex = torch.LongTensor{math.floor(torch.uniform(1, sz1)), math.floor(torch.uniform(1, sz1))}
    val = torch.randn(1)[1]
    compareFloatAndCuda(x, 'indexFill', index, longIndex, val)
+
+   tester:assert(isEqual(
+      x:cuda():indexFill(index, longIndex:cuda(), val),
+      x:indexFill(index, longIndex, val)),
+      "Divergent results between CPU and CUDA for function 'indexFill'")
 
    checkMultiDevice(x, 'indexFill', index, longIndex, val)
 end

--- a/torch/generic/Tensor.c
+++ b/torch/generic/Tensor.c
@@ -383,31 +383,38 @@ static int torch_Tensor_(indexSelect)(lua_State *L)
 {
   THCState *state = cutorch_getstate(L);
   int narg = lua_gettop(L);
-  THTensor *tensor, *src;
-  THLongTensor *index;
+  THTensor *tensor, *src, *index;
+  THLongTensor *longIndex;
   int dim;
   if (narg == 3)
   {
     tensor = THTensor_(new)(state);
     src = luaT_checkudata(L, 1, torch_Tensor);
     dim = luaL_checkint(L, 2) - 1;
-    index = luaT_checkudata(L, 3, "torch.LongTensor");
+    index = luaT_toudata(L, 3, torch_Tensor);
+    longIndex = luaT_toudata(L, 3, "torch.LongTensor");
+    if (!index && !longIndex) luaT_typerror(L, 3, "LongTensor | Tensor");
     luaT_pushudata(L,tensor,torch_Tensor);
   }
   else if(narg == 4)
   {
     src = luaT_checkudata(L, 2, torch_Tensor);
     dim = luaL_checkint(L, 3) - 1;
-    index = luaT_checkudata(L, 4, "torch.LongTensor");
+    index = luaT_toudata(L, 4, torch_Tensor);
+    longIndex = luaT_toudata(L, 4, "torch.LongTensor");
+    if (!index && !longIndex) luaT_typerror(L, 4, "Tensor | LongTensor");
     tensor = luaT_checkudata(L,1,torch_Tensor);
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor | Tensor, Tensor, number, LongTensor expected");
+    luaL_error(L, "[Tensor,] Tensor, number, Tensor | LongTensor expected");
     return 0;
   }
 
-  THTensor_(indexSelect)(state, tensor,src,dim,index);
+  if (index)
+    THTensor_(indexSelect)(state, tensor,src,dim,index);
+  else
+    THTensor_(indexSelect_long)(state, tensor,src,dim,longIndex);
 
   return 1;
 }
@@ -415,23 +422,28 @@ static int torch_Tensor_(indexSelect)(lua_State *L)
 static int torch_Tensor_(indexCopy)(lua_State *L)
 {
   int narg = lua_gettop(L);
-  THTensor *tensor, *src;
-  THLongTensor *index;
+  THTensor *tensor, *src, *index;
+  THLongTensor *longIndex;
   int dim;
   if(narg == 4)
   {
     dim = luaL_checkint(L, 2) - 1;
-    index = luaT_checkudata(L, 3, "torch.LongTensor");
+    index = luaT_toudata(L, 3, torch_Tensor);
+    longIndex = luaT_toudata(L, 3, "torch.LongTensor");
+    if (!index && !longIndex) luaT_typerror(L, 3, "Tensor | LongTensor");
     src = luaT_checkudata(L, 4, torch_Tensor);
     tensor = luaT_checkudata(L,1,torch_Tensor);
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor, Tensor expected");
+    luaL_error(L,"Tensor, number, Tensor | LongTensor, Tensor expected");
     return 0;
   }
 
-  THTensor_(indexCopy)(cutorch_getstate(L), tensor,dim,index,src);
+  if (index)
+    THTensor_(indexCopy)(cutorch_getstate(L), tensor,dim,index,src);
+  else
+    THTensor_(indexCopy_long)(cutorch_getstate(L), tensor,dim,longIndex,src);
 
   return 1;
 }
@@ -439,24 +451,29 @@ static int torch_Tensor_(indexCopy)(lua_State *L)
 static int torch_Tensor_(indexFill)(lua_State *L)
 {
   int narg = lua_gettop(L);
-  THTensor *tensor;
-  THLongTensor *index;
+  THTensor *tensor, *index;
+  THLongTensor *longIndex;
   real val;
   int dim;
   if(narg == 4)
   {
     dim = luaL_checkint(L, 2) - 1;
-    index = luaT_checkudata(L, 3, "torch.LongTensor");
+    index = luaT_toudata(L, 3, torch_Tensor);
+    longIndex = luaT_toudata(L, 3, "torch.LongTensor");
+    if (!index && !longIndex) luaT_typerror(L, 3, "Tensor | LongTensor");
     val = luaL_checknumber(L, 4);
     tensor = luaT_checkudata(L,1,torch_Tensor);
   }
   else
   {
-    luaL_error(L,"Tensor, number, LongTensor, number expected");
+    luaL_error(L,"Tensor, number, Tensor | LongTensor, number expected");
     return 0;
   }
 
-  THTensor_(indexFill)(cutorch_getstate(L), tensor,dim,index,val);
+  if (index)
+    THTensor_(indexFill)(cutorch_getstate(L), tensor,dim,index,val);
+  else
+    THTensor_(indexFill_long)(cutorch_getstate(L), tensor,dim,longIndex,val);
 
   return 1;
 }


### PR DESCRIPTION
Allow indexFill, indexCopy, and index to accept CudaTensors as indices
instead of LongTensors. We already just do a copy from LongTensor to
CudaTensor in the cutorch implementations, so this changes doesn't
result in any additional loss in precision.