### PR TITLE
Use Thrust's sort for inputs larger than 2048

### DIFF
--- a/lib/THC/THCTensorSort.cu
+++ b/lib/THC/THCTensorSort.cu
@@ -361,7 +361,7 @@ bool canSortThrust(THCState* state, THCudaTensor* input, int dim) {
   // the number of slices are small, and they are large
   return ((THCudaTensor_stride(state, input, dim) == 1) &&
           numSlices <= 16 &&
-          sliceSize > 4096);
+          sliceSize > 2048);
 }
 
 void THCudaTensor_sortImplThrust(THCState* state,


### PR DESCRIPTION
The blockwide sort kernel only supports inputs up to 2048 elements.
Before this change, attempting to sort inputs with size (2048,4096]
would fail.