### PR TITLE
Use standard Torch mechanism for file/line propagation in error messa…

### DIFF
--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -237,8 +237,8 @@ void __THCudaCheck(cudaError_t err, const char *file, const int line)
 {
   if(err != cudaSuccess)
   {
-    THError("%s(%i) : cuda runtime error (%d) : %s",
-            file, line, err, cudaGetErrorString(err));
+    _THError(file, line, "cuda runtime error (%d) : %s", err,
+             cudaGetErrorString(err));
   }
 }
 
@@ -283,8 +283,7 @@ void __THCublasCheck(cublasStatus_t status, const char *file, const int line)
         break;
     }
 
-    THError("%s(%i) : cublas runtime error : %s",
-            file, line, errmsg);
+    _THError(file, line, "%s(%i) : cublas runtime error : %s", errmsg);
   }
 }
 

--- a/lib/THC/THCGeneral.h
+++ b/lib/THC/THCGeneral.h
@@ -29,7 +29,7 @@
 #define THAssert(exp)                                                   \
   do {                                                                  \
     if (!(exp)) {                                                       \
-      THError("assert(%s) failed in file %s, line %d", #exp, __FILE__, __LINE__); \
+      _THError(__FILE__, __LINE__, "assert(%s) failed", #exp);          \
     }                                                                   \
   } while(0)
 #endif


### PR DESCRIPTION
…ges.

Avoids having two different file/line pairs per error message, which is
confusing.

Before:
.../cutorch/init.c(538) : cuda runtime error (10) : invalid device ordinal at .../cutorch/lib/THC/THCGeneral.c:241

Now:
cuda runtime error (10) : invalid device ordinal at .../cutorch/init.c:538