### PR TITLE
Remove broken apply, map and map2 functions.

### DIFF
--- a/torch/generic/Tensor.c
+++ b/torch/generic/Tensor.c
@@ -1054,84 +1054,6 @@ static void torch_Tensor_(c_readTensorStorageSizeStride)(lua_State *L, int index
       luaL_argcheck(L, 0, index, "expecting number");
 }
 
-static int torch_Tensor_(apply)(lua_State *L)
-{
-  THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
-  luaL_checktype(L, 2, LUA_TFUNCTION);
-  lua_settop(L, 2);
-
-  TH_TENSOR_APPLY(real, tensor,
-                  lua_pushvalue(L, 2);
-                  lua_pushnumber(L, *tensor_data);
-                  lua_call(L, 1, 1);
-                  if(lua_isnumber(L, 3))
-                  {
-                    *tensor_data = (real)lua_tonumber(L, 3);
-                    lua_pop(L, 1);
-                  }
-                  else if(lua_isnil(L, 3))
-                    lua_pop(L, 1);
-                  else
-                    luaL_error(L, "given function should return a number or nil"););
-
-  lua_settop(L, 1);
-  return 1;
-}
-
-static int torch_Tensor_(map)(lua_State *L)
-{
-  THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
-  THTensor *src = luaT_checkudata(L, 2, torch_Tensor);
-  luaL_checktype(L, 3, LUA_TFUNCTION);
-  lua_settop(L, 3);
-
-  TH_TENSOR_APPLY2(real, tensor, real, src,
-                  lua_pushvalue(L, 3);
-                  lua_pushnumber(L, *tensor_data);
-                  lua_pushnumber(L, *src_data);
-                  lua_call(L, 2, 1);
-                  if(lua_isnumber(L, 4))
-                  {
-                    *tensor_data = (real)lua_tonumber(L, 4);
-                    lua_pop(L, 1);
-                  }
-                  else if(lua_isnil(L, 4))
-                    lua_pop(L, 1);
-                  else
-                    luaL_error(L, "given function should return a number or nil"););
-
-  lua_settop(L, 1);
-  return 1;
-}
-
-static int torch_Tensor_(map2)(lua_State *L)
-{
-  THTensor *tensor = luaT_checkudata(L, 1, torch_Tensor);
-  THTensor *src1 = luaT_checkudata(L, 2, torch_Tensor);
-  THTensor *src2 = luaT_checkudata(L, 3, torch_Tensor);
-  luaL_checktype(L, 4, LUA_TFUNCTION);
-  lua_settop(L, 4);
-
-  TH_TENSOR_APPLY3(real, tensor, real, src1, real, src2,
-                  lua_pushvalue(L, 4);
-                  lua_pushnumber(L, *tensor_data);
-                  lua_pushnumber(L, *src1_data);
-                  lua_pushnumber(L, *src2_data);
-                  lua_call(L, 3, 1);
-                  if(lua_isnumber(L, 5))
-                  {
-                    *tensor_data = (real)lua_tonumber(L, 5);
-                    lua_pop(L, 1);
-                  }
-                  else if(lua_isnil(L, 5))
-                    lua_pop(L, 1);
-                  else
-                    luaL_error(L, "given function should return a number or nothing"););
-
-  lua_settop(L, 1);
-  return 1;
-}
-
 static int torch_Tensor_(factory)(lua_State *L)
 {
   THTensor *tensor = THTensor_(new)(cutorch_getstate(L));
@@ -1216,9 +1138,6 @@ static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"isSameSizeAs", torch_Tensor_(isSameSizeAs)},
   {"nElement", torch_Tensor_(nElement)},
   {"copy", torch_Tensor_(copy)},
-  {"apply", torch_Tensor_(apply)},
-  {"map", torch_Tensor_(map)},
-  {"map2", torch_Tensor_(map2)},
   {"read", torch_Tensor_(read)},
   {"write", torch_Tensor_(write)},
   {"__index__", torch_Tensor_(__index__)},


### PR DESCRIPTION
They were copied from torch, using TH_TENSOR_APPLY macros which don't
work with CudaTensors.
If we want to make this work without having to resort to copying data to
the CPU, we'd have to do runtime compilation as suggested in #118. But
for now I think we should just remove these functions here.