### PR TITLE
small fix for MSVC

### DIFF
--- a/lib/THC/THCApply.cuh
+++ b/lib/THC/THCApply.cuh
@@ -16,7 +16,7 @@
 
 // Called when we are copying into an overlapping index `dst`, but
 // we don't care which writer wins. Hacky but it works.
-void THCudaTensor_copyIgnoringOverlaps(THCState* state,
+THC_API void THCudaTensor_copyIgnoringOverlaps(THCState* state,
                                        THCudaTensor* dst,
                                        THCudaTensor* src);
 


### PR DESCRIPTION
THCudaTensor_copyIgnoringOverlaps needed to be exported for cunn.