### PR TITLE
Fix for gemm with zero strides

### DIFF
--- a/lib/THC/THCTensorMathBlas.cu
+++ b/lib/THC/THCTensorMathBlas.cu
@@ -102,12 +102,14 @@ void THCudaTensor_addmm(THCState *state, THCudaTensor *r_, float beta, THCudaTen
   }
 
   /* r_ */
-  if(r_->stride[0] == 1)
+  if(r_->stride[0] == 1 &&
+     r_->stride[1] != 0)
   {
     transpose_r = 'n';
     r__ = r_;
   }
-  else if(r_->stride[1] == 1)
+  else if(r_->stride[1] == 1 &&
+          r_->stride[0] != 0)
   {
     THCudaTensor *swap = m2;
     m2 = m1;
@@ -125,12 +127,14 @@ void THCudaTensor_addmm(THCState *state, THCudaTensor *r_, float beta, THCudaTen
   }
 
   /* m1 */
-  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1)
+  if(m1->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
+     m1->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
   {
     transpose_m1 = 'n';
     m1_ = m1;
   }
-  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1)
+  else if(m1->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
+          m1->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
   {
     transpose_m1 = 't';
     m1_ = m1;
@@ -142,12 +146,14 @@ void THCudaTensor_addmm(THCState *state, THCudaTensor *r_, float beta, THCudaTen
   }
 
   /* m2 */
-  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1)
+  if(m2->stride[(transpose_r == 'n' ? 0 : 1)] == 1 &&
+     m2->stride[(transpose_r == 'n' ? 1 : 0)] != 0)
   {
     transpose_m2 = 'n';
     m2_ = m2;
   }
-  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1)
+  else if(m2->stride[(transpose_r == 'n' ? 1 : 0)] == 1 &&
+          m2->stride[(transpose_r == 'n' ? 0 : 1)] != 0)
   {
     transpose_m2 = 't';
     m2_ = m2;

--- a/test/test.lua
+++ b/test/test.lua
@@ -1188,6 +1188,50 @@ function test.addmm()
          multiCheck = true
       end
    end
+
+   -- check all zero-strided cases for the inputs
+   -- considers that the output tensor is not zero-strided
+   local n, k, m = 10, 10, 10
+   local function generateTensor(t,idx)
+      local tensor = torch.FloatTensor()
+      local s1,s2
+      if t == 1 then
+        s1 = n
+        s2 = m
+      elseif t == 2 then
+        s1 = n
+        s2 = k
+      else
+        s1 = k
+        s2 = m
+      end
+      if idx == 1 then
+        tensor:resize(s1,s2)
+      elseif idx == 2 then
+        tensor:resize(s1,1)
+      elseif idx == 3 then
+        tensor:resize(1,s2)
+      else
+        tensor:resize(1,1)
+      end
+      if t == 1 then
+        tensor:zero()
+      else
+        tensor:uniform()
+      end
+      tensor = tensor:expand(s1,s2)
+      return tensor
+   end
+   
+   for i = 1, 4*4*4 do
+      local a_idx = (i-1)%4 + 1
+      local b_idx = math.floor(((i-1)%16)/4)  + 1
+      local c_idx = 1 -- math.floor((i-1)/16) + 1
+      local c = generateTensor(1,c_idx)
+      local a = generateTensor(2,a_idx)
+      local b = generateTensor(3,b_idx)
+      compareFloatAndCudaTensorArgs(c, 'addmm', torch.normal(), torch.normal(), a, b)
+   end
 end
 
 function test.mm()
@@ -1212,6 +1256,50 @@ function test.mm()
          checkMultiDevice(c, 'mm', a, b)
          multiCheck = true
       end
+   end
+
+   -- check all zero-strided cases for the inputs
+   -- considers that the output tensor is not zero-strided
+   local n, k, m = 10, 10, 10
+   local function generateTensor(t,idx)
+      local tensor = torch.FloatTensor()
+      local s1,s2
+      if t == 1 then
+        s1 = n
+        s2 = m
+      elseif t == 2 then
+        s1 = n
+        s2 = k
+      else
+        s1 = k
+        s2 = m
+      end
+      if idx == 1 then
+        tensor:resize(s1,s2)
+      elseif idx == 2 then
+        tensor:resize(s1,1)
+      elseif idx == 3 then
+        tensor:resize(1,s2)
+      else
+        tensor:resize(1,1)
+      end
+      if t == 1 then
+        tensor:zero()
+      else
+        tensor:uniform()
+      end
+      tensor = tensor:expand(s1,s2)
+      return tensor
+   end
+   
+   for i = 1, 4*4*4 do
+      local a_idx = (i-1)%4 + 1
+      local b_idx = math.floor(((i-1)%16)/4)  + 1
+      local c_idx = 1 -- math.floor((i-1)/16) + 1
+      local c = generateTensor(1,c_idx)
+      local a = generateTensor(2,a_idx)
+      local b = generateTensor(3,b_idx)
+      compareFloatAndCudaTensorArgs(c, 'mm', a, b)
    end
 end
 


### PR DESCRIPTION
Fixes https://github.com/torch/cutorch/issues/213

There is still one issue though (also present in `torch`), when the output Tensor has zero stride and the good dimensions the results are not right.
This is probably due to an issue with `freeCopyTo`. Indeed, it calls `copy`, which doesn't work as expected when the destination Tensor has zero stride and the good dimensions, as discussed in https://github.com/torch/torch7/issues/289.

