### PR TITLE
stream event fixes

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -2169,7 +2169,7 @@ function test.streamWaitFor()
    end
 
    -- Queue a bunch of work on different streams
-   for stream = 1, numStreams do
+   for stream = numStreams, 1, -1 do
       cutorch.setStream(stream)
       for i = 1, iter do
          tensors[stream]:add(1)
@@ -2309,7 +2309,7 @@ function test.streamBarrier()
    end
 
    -- Queue a bunch of work on different streams
-   for stream = 1, numStreams do
+   for stream = numStreams, 1, -1 do
       cutorch.setStream(stream)
       for i = 1, iter do
          tensors[stream]:add(1)


### PR DESCRIPTION
This patch was sent by Natalia Gimelshein from NVIDIA. Thanks Natalia.

Verbatim copy/paste of email:

I've noticed that there is incorrect implementation of cutorch stream synchronization functions, such as cutorch.streamWaitFor, cutorch.streamBarrier and cutorch.streamWaitForMultiDevice. One event per GPU is created, that it is recorded on each stream in the "synchronize with" list, and the cudaStreamWaitEvent is called in the waiting stream for this event. However, documentation
http://developer.download.nvidia.com/compute/cuda/4_1/rel/toolkit/docs/online/group__CUDART__EVENT_ga324d5ce3fbf46899b15e5e42ff9cfa5.html
says 
"If cudaEventRecord() has previously been called on event, then this call will overwrite any existing state in event. Any subsequent calls which examine the status of event will only examine the completion of this most recent call to cudaEventRecord()."
So the synchronization was performed only with the last stream on which the event was recorded. Tests passed because the work was enqueued to the streams in order, and last stream was done last. However, even when enqueueing work in order, there is no guarantee that the last stream will be done last, and besides, there is no requirement that work should be enqueued in order.
In addition, in cudaStreamWaitForMultiDevice the check should be if there is at least 1 stream to wait on, not 2, as currently.
I'm attaching a patch fixing these issues. I've also changed test.lua to enqueue work to streams in reverse order, so tests fail with current implementation, but pass with my patch.
