### PR TITLE
Add copyAsync for asynchronous copies between host and device.

### DIFF
--- a/lib/THC/THCTensorCopy.c
+++ b/lib/THC/THCTensorCopy.c
@@ -6,13 +6,16 @@
 
 void THCudaTensor_copyFloat(THCState *state, THCudaTensor *self, struct THFloatTensor *src)
 {
-  THArgCheck(THCudaTensor_nElement(state, self) == THFloatTensor_nElement(src), 2, "sizes do not match"); 
+  THArgCheck(THCudaTensor_nElement(state, self) == THFloatTensor_nElement(src), 2, "sizes do not match");
 
   {
     THCudaTensor *selfc = THCudaTensor_newContiguous(state, self);
     src = THFloatTensor_newContiguous(src);
-  
-    THCudaCheck(cudaMemcpy(selfc->storage->data + selfc->storageOffset, src->storage->data + src->storageOffset, THFloatTensor_nElement(src) * sizeof(float), cudaMemcpyHostToDevice));
+
+    THCudaCheck(cudaMemcpy(THCudaTensor_data(state, selfc),
+                           THFloatTensor_data(src),
+                           THFloatTensor_nElement(src) * sizeof(float),
+                           cudaMemcpyHostToDevice));
 
     THFloatTensor_free(src);
     THCudaTensor_freeCopyTo(state, selfc, self);
@@ -54,8 +57,8 @@ void THFloatTensor_copyCuda(THCState *state, THFloatTensor *self, struct THCudaT
     THFloatTensor *selfc = THFloatTensor_newContiguous(self);
     src = THCudaTensor_newContiguous(state, src);
 
-    THCudaCheck(cudaMemcpy(selfc->storage->data + selfc->storageOffset,
-                           src->storage->data + src->storageOffset,
+    THCudaCheck(cudaMemcpy(THFloatTensor_data(selfc),
+                           THCudaTensor_data(state, src),
                            THCudaTensor_nElement(state, src) * sizeof(float),
                            cudaMemcpyDeviceToHost));
 
@@ -99,11 +102,27 @@ void THCudaTensor_copyAsyncFloat(THCState *state, THCudaTensor *self, struct THF
   THArgCheck(THCudaTensor_isContiguous(state, self), 2, "Target tensor must be contiguous");
   THArgCheck(THFloatTensor_isContiguous(src), 3, "Source tensor must be contiguous");
 
-  THCudaCheck(cudaMemcpyAsync(self->storage->data + self->storageOffset,
-                              src->storage->data + src->storageOffset,
+  if (THCudaTensor_nElement(state, self) == 0) return;
+
+  // Perform the copy wrt the current stream on the CudaTensor's device.
+  int tensorDevice = THCudaTensor_getDevice(state, self);
+  int currentDevice;
+  THCudaCheck(cudaGetDevice(&currentDevice));
+
+  if (currentDevice != tensorDevice) {
+    THCudaCheck(cudaSetDevice(tensorDevice));
+  }
+
+  THCudaCheck(cudaMemcpyAsync(THCudaTensor_data(state, self),
+                              THFloatTensor_data(src),
                               THFloatTensor_nElement(src) * sizeof(float),
                               cudaMemcpyHostToDevice,
-                              THCState_getCurrentStream(state)));
+                              THCState_getDeviceStream(state, tensorDevice,
+                                                       THCState_getCurrentStreamIndex(state))));
+
+  if (currentDevice != tensorDevice) {
+    THCudaCheck(cudaSetDevice(currentDevice));
+  }
 }
 
 void THFloatTensor_copyAsyncCuda(THCState *state, THFloatTensor *self, struct THCudaTensor *src)
@@ -112,9 +131,25 @@ void THFloatTensor_copyAsyncCuda(THCState *state, THFloatTensor *self, struct TH
   THArgCheck(THFloatTensor_isContiguous(self), 2, "Target tensor must be contiguous");
   THArgCheck(THCudaTensor_isContiguous(state, src), 3, "Source tensor must be contiguous");
 
-  THCudaCheck(cudaMemcpyAsync(self->storage->data + self->storageOffset,
-                              src->storage->data + src->storageOffset,
+  if (THFloatTensor_nElement(self) == 0) return;
+
+  // Perform the copy wrt the current stream on the CudaTensor's device.
+  int tensorDevice = THCudaTensor_getDevice(state, src);
+  int currentDevice;
+  THCudaCheck(cudaGetDevice(&currentDevice));
+
+  if (currentDevice != tensorDevice) {
+    THCudaCheck(cudaSetDevice(tensorDevice));
+  }
+
+  THCudaCheck(cudaMemcpyAsync(THFloatTensor_data(self),
+                              THCudaTensor_data(state, src),
                               THCudaTensor_nElement(state, src) * sizeof(float),
                               cudaMemcpyDeviceToHost,
-                              THCState_getCurrentStream(state)));
+                              THCState_getDeviceStream(state, tensorDevice,
+                                                       THCState_getCurrentStreamIndex(state))));
+
+  if (currentDevice != tensorDevice) {
+    THCudaCheck(cudaSetDevice(currentDevice));
+  }
 }

--- a/lib/THC/THCTensorCopy.h
+++ b/lib/THC/THCTensorCopy.h
@@ -22,4 +22,7 @@ THC_API void THFloatTensor_copyCuda(THCState *state, THFloatTensor *self, THCuda
 THC_API void THDoubleTensor_copyCuda(THCState *state, THDoubleTensor *self, THCudaTensor *src);
 THC_API void THCudaTensor_copyCuda(THCState *state, THCudaTensor *self, THCudaTensor *src);
 
+THC_API void THCudaTensor_copyAsyncFloat(THCState *state, THCudaTensor *self, THFloatTensor *src);
+THC_API void THFloatTensor_copyAsyncCuda(THCState *state, THFloatTensor *self, THCudaTensor *src);
+
 #endif

--- a/test/test.lua
+++ b/test/test.lua
@@ -476,6 +476,22 @@ function test.copyNoncontiguous()
    end
 end
 
+function test.copyAsync()
+   local sz = chooseInt(maxsize, 2 * maxsize)
+   local host_tensor = cutorch.createCudaHostTensor(sz):uniform()
+   local device_tensor = torch.CudaTensor(sz)
+   device_tensor:copyAsync(host_tensor)
+   cutorch.streamSynchronize(cutorch.getStream())
+   tester:assertTensorEq(host_tensor, device_tensor:float(), 0,
+                         "Async copy to device failed.")
+
+   device_tensor:uniform()
+   host_tensor:copyAsync(device_tensor)
+   cutorch.streamSynchronize(cutorch.getStream())
+   tester:assertTensorEq(device_tensor:float(), host_tensor, 0,
+                         "Async copy to host failed.")
+end
+
 function test.largeNoncontiguous()
    local x = torch.FloatTensor():randn(20, 1, 60, 60)
    local sz = chooseInt(maxsize, 2 * maxsize)


### PR DESCRIPTION
As discussed in #216.

Only works for contiguous Float- and CudaTensors.