### PR TITLE
Batch updates to global heapSize

### DIFF
--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -78,6 +78,7 @@ typedef struct THCState
   void (*cutorchGCFunction)(void *data);
   void *cutorchGCData;
   long heapSoftmax;
+  long heapDelta;
 } THCState;
 
 THC_API void THCudaInit(THCState* state);


### PR DESCRIPTION
cutorch version of https://github.com/torch/torch7/pull/356

Multithreaded Torch programs that do many small THAllocs were
encountering contention on updating heapSize. Instead, keep track of
allocations and frees in a thread-local variable, heapDelta, and only
update the global heapSize when heapDelta exceeds +/- 1MB.
