### PR TITLE
cutorch copy fixes, add CUDA Event API to Lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,5 @@
 require "torch"
-cutorch = paths.require("libcutorch")
+paths.require "libcutorch"
 
 torch.CudaStorage.__tostring__ = torch.FloatStorage.__tostring__
 torch.CudaTensor.__tostring__ = torch.FloatTensor.__tostring__

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -75,6 +75,10 @@ typedef struct THCState
   /* Allocator using cudaMallocHost. */
   THAllocator* cudaHostAllocator;
 
+  /* Table of enabled peer-to-peer access between directed pairs of GPUs.
+     If i accessing allocs on j is enabled, p2pAccess[i][j] is 1; 0 otherwise. */
+  int** p2pAccessEnabled;
+
   void (*cutorchGCFunction)(void *data);
   void *cutorchGCData;
   long heapSoftmax;
@@ -85,6 +89,14 @@ THC_API void THCudaInit(THCState* state);
 THC_API void THCudaShutdown(THCState* state);
 THC_API void THCudaEnablePeerToPeerAccess(THCState* state);
 
+/* If device `dev` can access allocations on device `devToAccess`, this will return */
+/* 1; otherwise, 0. */
+THC_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess);
+/* Enables or disables allowed p2p access using cutorch copy. If we are */
+/* attempting to enable access, throws an error if CUDA cannot enable p2p */
+/* access. */
+THC_API void THCState_setPeerToPeerAccess(THCState* state, int dev, int devToAccess,
+                                          int enable);
 THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* state);
 
 THC_API void THCMagma_init(THCState *state);
@@ -124,7 +136,7 @@ THC_API void __THCublasCheck(cublasStatus_t status, const char *file, const int 
 THC_API cudaError_t THCudaMalloc(THCState *state, void **ptr, size_t size);
 THC_API cudaError_t THCudaFree(THCState *state, void *ptr);
 THC_API void THCSetGCHandler(THCState *state,
-                             void (*torchGCHandlerFunction)(void *data), 
+                             void (*torchGCHandlerFunction)(void *data),
                              void *data );
 THC_API void THCHeapUpdate(THCState *state, long size);
 

--- a/lib/THC/THCTensorCopy.cu
+++ b/lib/THC/THCTensorCopy.cu
@@ -28,62 +28,141 @@ THCudaTensor_copy(THCState* state, THCudaTensor* dst, THCudaTensor* src) {
   bool dstContig = THCudaTensor_isContiguous(state, dst);
   bool memcpyEligible = (srcContig && dstContig) || (totalElements == 1);
 
-  int oldDev = curGPU();
   int srcDev = THCudaTensor_getDevice(state, src);
   int dstDev = THCudaTensor_getDevice(state, dst);
+  int oldDev = curGPU();
 
-  // empirically, running the kernel on the device that holds the
-  // non-contiguous tensor is faster by 5-10x
-  int copyDev   = dstContig ? srcDev : dstDev;
-  int remoteDev = dstContig ? dstDev : srcDev;
+  // We always perform the copy on the source device, using the
+  // current stream on the source device.
+  // If the copy is on the default stream, then we fully synchronize
+  // both src and dst's default streams for completion of the
+  // copy. We have to explicitly do this for non-contig copies.
+  // This mimics the behavior of cross-device cudaMemcpyAsync on
+  // the default stream.
+  // If the copy is not on the default stream, then it is up to the
+  // user to add needed synchronization on the dst device, since the
+  // stream on the dst device that wishes to synchronize may not be
+  // the same index as the one on the src device.
+  int copyStreamIndex =
+    THCState_getCurrentStreamIndex(state);
+  cudaStream_t copyStream =
+    THCState_getDeviceStream(state, srcDev, copyStreamIndex);
 
-  if (srcDev == dstDev) {
-    if (oldDev != srcDev) {
-      THCudaCheck(cudaSetDevice(srcDev));
-    }
-  } else {
-    // synchronize remote device before copy
-    cudaEvent_t dataReady;
-    THCudaCheck(cudaSetDevice(remoteDev));
-    THCudaCheck(cudaEventCreate(&dataReady));
-    THCudaCheck(cudaEventRecord(
-                  dataReady,
-                  THCState_getDeviceStream(state, remoteDev, THCState_getCurrentStreamIndex(state))));
-    THCudaCheck(cudaSetDevice(copyDev));
-    THCudaCheck(cudaStreamWaitEvent(
-                  THCState_getDeviceStream(state, copyDev, THCState_getCurrentStreamIndex(state)),
-                  dataReady, 0));
-    THCudaCheck(cudaEventDestroy(dataReady));
+  if (srcDev != dstDev && copyStreamIndex == 0) {
+    // This is a cross-device copy on the default stream. We perform a
+    // two-way barrier between both devices' default streams before
+    // the copy. This ensures that any write-after-write and
+    // write-after-read dependencies on the destination side are
+    // handled, so that no one is operating on the dst memory when
+    // we perform the copy.
+    // src waits on dst barrier (src already waits on src)
+    cudaEvent_t dstReady;
+    THCudaCheck(cudaSetDevice(dstDev));
+    THCudaCheck(cudaEventCreateWithFlags(&dstReady, cudaEventDisableTiming));
+    THCudaCheck(cudaEventRecord(dstReady, NULL));
+
+    THCudaCheck(cudaSetDevice(srcDev));
+    THCudaCheck(cudaStreamWaitEvent(NULL, dstReady, 0));
+    THCudaCheck(cudaEventDestroy(dstReady));
+  } else if (srcDev != oldDev) {
+    THCudaCheck(cudaSetDevice(srcDev));
   }
 
+  // We are now on srcDev
   if (memcpyEligible) {
+    // Perform the copy
     THCudaCheck(cudaMemcpyAsync(THCudaTensor_data(state, dst),
                                 THCudaTensor_data(state, src),
                                 totalElements * sizeof(float),
                                 cudaMemcpyDeviceToDevice,
-                                THCState_getCurrentStream(state)));
+                                copyStream));
   } else {
+    // Non-contiguous copy
+
+    // We avoid creating temporary memory copies if possible.
+    // If both src and dst are on the same device, or if they are on
+    // different devices and p2p access is enabled, perform the copy
+    // by a pointwise copy kernel.
+    // Otherwise, we'll have to make contiguous (which will in fact
+    // invoke copy() again), and then perform the copy.
+    // FIXME: might want to consider only running the pointwise kernel
+    // if both src and dst innermost dimensions are contiguous. If
+    // they are not, then taking the hit of the memory allocation/free
+    // might be worth it to avoid non-coalesced reads or writes.
+
+    // A device always has access to itself, so this also handles the
+    // case srcDev == dstDev
+    if (THCState_getPeerToPeerAccess(state, srcDev, dstDev)) {
+      // Make sure we have the current stream set in THCState, since
+      // pointwise uses that
+      if (srcDev != oldDev) {
+        THCState_setStream(state, srcDev, copyStreamIndex);
+      }
+
       bool succ =
         THCudaTensor_pointwiseApply2(state, dst, src, CopyOp<float>());
       THArgCheck(succ, 2, CUTORCH_DIM_WARNING);
+
+      // Restore prior THCState stream
+      if (srcDev != oldDev) {
+        THCState_setStream(state, oldDev, copyStreamIndex);
+      }
+    } else {
+      // GPUs can't access each other directly; fall back to
+      // newContiguous and memcpy
+      THCudaTensor* srcContig = THCudaTensor_newContiguous(state, src);
+      THCudaTensor* dstContig = dst;
+
+      if (!THCudaTensor_isContiguous(state, dst)) {
+        // We are copying over the contents of dst, so we don't need
+        // to preserve its values. We just need a destination tensor
+        // the same size as dst.
+
+        // Allocate the tensor on the new device
+        THCudaCheck(cudaSetDevice(dstDev));
+
+        dstContig = THCudaTensor_new(state);
+        THCudaTensor_resizeAs(state, dstContig, dst);
+
+        THCudaCheck(cudaSetDevice(srcDev));
+      }
+
+      THCudaCheck(cudaMemcpyAsync(THCudaTensor_data(state, dstContig),
+                                  THCudaTensor_data(state, srcContig),
+                                  totalElements * sizeof(float),
+                                  cudaMemcpyDeviceToDevice,
+                                  copyStream));
+
+      THCudaTensor_free(state, srcContig);
+
+      if (dst != dstContig) {
+        THCudaTensor_freeCopyTo(state, dstContig, dst);
+      }
+    }
   }
 
-  if (srcDev != dstDev) {
-    // synchronize remote device after copy
-    cudaEvent_t doneCopying;
-    THCudaCheck(cudaEventCreate(&doneCopying));
-    THCudaCheck(cudaEventRecord(
-                  doneCopying,
-                  THCState_getDeviceStream(state, copyDev, THCState_getCurrentStreamIndex(state))));
-    THCudaCheck(cudaSetDevice(remoteDev));
-    THCudaCheck(cudaStreamWaitEvent(
-                  THCState_getDeviceStream(state, remoteDev, THCState_getCurrentStreamIndex(state)),
-                  doneCopying, 0));
-    THCudaCheck(cudaEventDestroy(doneCopying));
-  }
+  if (srcDev != dstDev && copyStreamIndex == 0) {
+    // dst waits on src barrier (dst already waits on dst). We cannot
+    // operate on dst's copy until the copy is complete.
 
-  if (curGPU() != oldDev) {
-    THCudaCheck(cudaSetDevice(oldDev));
+    // Still on srcDev, record default stream event
+    cudaEvent_t srcReady;
+    THCudaCheck(cudaEventCreateWithFlags(&srcReady, cudaEventDisableTiming));
+    THCudaCheck(cudaEventRecord(srcReady, NULL));
+
+    THCudaCheck(cudaSetDevice(dstDev));
+    THCudaCheck(cudaStreamWaitEvent(NULL, srcReady, 0));
+    THCudaCheck(cudaEventDestroy(srcReady));
+
+    // We are now on dstDev (right above). Restore prior device from dst
+    if (dstDev != oldDev) {
+      THCudaCheck(cudaSetDevice(oldDev));
+    }
+  } else {
+    // We are still on srcDev. Restore prior device from src
+    if (srcDev != oldDev) {
+      THCudaCheck(cudaSetDevice(oldDev));
+    }
   }
 
   cudaError errcode = cudaGetLastError();


### PR DESCRIPTION
Fixes:

https://github.com/torch/cutorch/issues/239
https://github.com/torch/cutorch/issues/212
https://github.com/torch/cutorch/issues/134

If p2p access cannot be enabled, then we default to make contig + cudaMemcpyAsync. This just happens for all GPUs instead of trying to restrict it to the pairs of GPUs for which p2p access cannot be enabled.

Implements the async copy behavior changes outlined in #212.

Also adds a Lua-level CUDA event API. GC of this object will free the CUDA event.

Also makes cutorch mirror the `cutorch` table definition that torch7 has, a change @andresy wanted me to make when I was mucking with the event stuff internally.
