### PR TITLE
faster norm/normall code

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -1048,6 +1048,22 @@ function test.indexFill()
    checkMultiDevice(x, 'indexFill', index, longIndex, val)
 end
 
+function test.norm()
+   for i = 1, 5 do
+      for n = 0, 3 do
+         local cpu = torch.FloatTensor(chooseInt(20, 50), 2):uniform(-0.5, 0.5)
+
+         if torch.random(1, 2) == 1 then
+            cpu = cpu:transpose(1, 2)
+         end
+
+         compareFloatAndCuda(cpu, 'norm', n)
+         compareFloatAndCuda(cpu, 'norm', n, 1)
+         compareFloatAndCuda(cpu, 'norm', n, 2)
+      end
+   end
+end
+
 function test.renorm()
    local x = torch.randn(10,5):float()
    local maxnorm = x:norm(2,1):mean()


### PR DESCRIPTION
Use template specialization to avoid unnecessary pow, switch to float form.

Speedup for normall (2-norm):

old code 

tensor size | time (ms)
----|----
10000 | 0.19192695617676
100000 | 0.18906593322754
1000000 | 0.31685829162598
10000000 | 1.3060569763184
100000000 | 11.244058609009

new code 

tensor size | time (ms)
----|----
10000 | 0.12993812561035
100000 | 0.15497207641602
1000000 | 0.14400482177734
10000000 | 0.34999847412109
100000000 | 2.2017955780029
