### PR TITLE
Allow passing no arguments to cutorch.createCudaHostTensor

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -24,9 +24,17 @@ end
 -- Creates a FloatTensor using the CudaHostAllocator.
 -- Accepts either a LongStorage or a sequence of numbers.
 function cutorch.createCudaHostTensor(...)
-  local size = torch.LongTensor(torch.isStorage(...) and ... or {...})
-  local storage = torch.FloatStorage(cutorch.CudaHostAllocator, size:prod())
-  return torch.FloatTensor(storage, 1, size:storage())
+   local size
+   if not ... then
+      size = torch.LongTensor{0}
+   elseif torch.isStorage(...) then
+      size = torch.LongTensor(...)
+   else
+      size = torch.LongTensor{...}
+   end
+
+   local storage = torch.FloatStorage(cutorch.CudaHostAllocator, size:prod())
+   return torch.FloatTensor(storage, 1, size:storage())
 end
 
 cutorch.setHeapTracking(true)

--- a/test/test.lua
+++ b/test/test.lua
@@ -2553,6 +2553,10 @@ function test.cudaHostTensor()
   local u = torch.Tensor(4, 5, 6)
   local v = cutorch.createCudaHostTensor(u:size())
   tester:assertTableEq(u:size():totable(), v:size():totable())
+
+  local w = cutorch.createCudaHostTensor()
+  tester:assert(w:storage() ~= nil, 'Empty CUDA host tensor must have a storage')
+  tester:asserteq(w:nElement(), 0, 'Expected an empty tensor')
 end
 
 -- unfortunately, torch.Tester() forgot setUp and tearDown functions.


### PR DESCRIPTION
Still creates a storage because of the non-default allocator.