### PR TITLE
Allow to specify CUDA arch via env variable

### DIFF
--- a/cmake/FindCudaArch.cmake
+++ b/cmake/FindCudaArch.cmake
@@ -94,6 +94,13 @@ FUNCTION(SELECT_NVCC_ARCH_FLAGS out_variable)
     unSET(CUDA_ARCH_PTX CACHE)
   ENDIF()
 
+  # Allow a user to specify architecture from env
+  IF($ENV{CUDA_ARCH_BIN})
+    SET(CUDA_ARCH_NAME "Manual")
+    SET(CUDA_ARCH_BIN $ENV{CUDA_ARCH_BIN})
+    unSET(CUDA_ARCH_PTX)
+  ENDIF()
+
   IF(${CUDA_ARCH_NAME} STREQUAL "Fermi")
     SET(__cuda_arch_bin "2.0 2.1(2.0)")
   elseIF(${CUDA_ARCH_NAME} STREQUAL "Kepler")


### PR DESCRIPTION
You can now disable the whole detection process by setting the `CUDA_ARCH_BIN` environment variable:
```bash
CUDA_ARCH_BIN=2.0 luarocks install cutorch
```

Tested with #278 : It properly skipped the detection mechanism (even though this does not fix the issue since the problem is somewhere else).