### PR TITLE
Fix tensor index bugs and performance; better testing

### DIFF
--- a/lib/THC/THCApply.cuh
+++ b/lib/THC/THCApply.cuh
@@ -197,10 +197,12 @@ bool THCudaTensor_pointwiseApply1(THCState* state,
   // additional overhead.
   if (THC_canUse32BitIndexMath(state, a)) {
     TensorInfo<unsigned int> aInfo(state, a);
+    aInfo.collapseDims();
 
     HANDLE_A_CASE(unsigned int, aInfo.dims);
   } else {
     TensorInfo<unsigned long> aInfo(state, a);
+    aInfo.collapseDims();
 
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce
@@ -343,12 +345,18 @@ bool THCudaTensor_pointwiseApply2(THCState* state,
   if (THC_canUse32BitIndexMath(state, a) &&
       THC_canUse32BitIndexMath(state, b)) {
     TensorInfo<unsigned int> aInfo(state, a);
+    aInfo.collapseDims();
+
     TensorInfo<unsigned int> bInfo(state, b);
+    bInfo.collapseDims();
 
     HANDLE_A_CASE(unsigned int, aInfo.dims, bInfo.dims);
   } else {
     TensorInfo<unsigned long> aInfo(state, a);
+    aInfo.collapseDims();
+
     TensorInfo<unsigned long> bInfo(state, b);
+    bInfo.collapseDims();
 
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce
@@ -528,14 +536,24 @@ bool THCudaTensor_pointwiseApply3(THCState* state,
       THC_canUse32BitIndexMath(state, b) &&
       THC_canUse32BitIndexMath(state, c)) {
     TensorInfo<unsigned int> aInfo(state, a);
+    aInfo.collapseDims();
+
     TensorInfo<unsigned int> bInfo(state, b);
+    bInfo.collapseDims();
+
     TensorInfo<unsigned int> cInfo(state, c);
+    cInfo.collapseDims();
 
     HANDLE_A_CASE(unsigned int, aInfo.dims, bInfo.dims, cInfo.dims);
   } else {
     TensorInfo<unsigned long> aInfo(state, a);
+    aInfo.collapseDims();
+
     TensorInfo<unsigned long> bInfo(state, b);
+    bInfo.collapseDims();
+
     TensorInfo<unsigned long> cInfo(state, c);
+    cInfo.collapseDims();
 
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce

--- a/lib/THC/THCReduce.cuh
+++ b/lib/THC/THCReduce.cuh
@@ -268,12 +268,18 @@ bool THCudaTensor_reduceDim(THCState* state,
   if (THC_canUse32BitIndexMath(state, out) &&
       THC_canUse32BitIndexMath(state, in)) {
     TensorInfo<unsigned int> outInfo(state, out);
+    outInfo.collapseDims();
+
     TensorInfo<unsigned int> inInfo(state, in, dim);
+    inInfo.collapseDims();
 
     HANDLE_OUT_CASE(unsigned int, outInfo.dims, inInfo.dims);
   } else {
     TensorInfo<unsigned long> outInfo(state, out);
+    outInfo.collapseDims();
+
     TensorInfo<unsigned long> inInfo(state, in, dim);
+    inInfo.collapseDims();
 
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce

--- a/lib/THC/THCReduceAll.cuh
+++ b/lib/THC/THCReduceAll.cuh
@@ -251,10 +251,12 @@ bool THCudaTensor_reduceAll(THCState* state,
 
   if (THC_canUse32BitIndexMath(state, in)) {
     TensorInfo<unsigned int> inInfo(state, in);
+    inInfo.collapseDims();
 
     HANDLE_IN_CASE(unsigned int, inInfo.dims);
   } else {
     TensorInfo<unsigned long long> inInfo(state, in);
+    inInfo.collapseDims();
 
     // For large tensors, we only compile the completely contiguous
     // version and the completely generic version, to reduce

--- a/lib/THC/THCTensorScatterGather.cu
+++ b/lib/THC/THCTensorScatterGather.cu
@@ -145,9 +145,9 @@ void THCudaTensor_gather(THCState* state, THCudaTensor *tensor, THCudaTensor *sr
   if (THC_canUse32BitIndexMath(state, tensor) &&
       THC_canUse32BitIndexMath(state, src) &&
       THC_canUse32BitIndexMath(state, index)) {
-    TensorInfo<unsigned int> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned int> srcInfo(state, src, NoCollapseDims);
-    TensorInfo<unsigned int> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned int> tensorInfo(state, tensor);
+    TensorInfo<unsigned int> srcInfo(state, src);
+    TensorInfo<unsigned int> indexInfo(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -165,9 +165,9 @@ void THCudaTensor_gather(THCState* state, THCudaTensor *tensor, THCudaTensor *sr
         break;
     }
   } else {
-    TensorInfo<unsigned long> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned long> srcInfo(state, src, NoCollapseDims);
-    TensorInfo<unsigned long> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned long> tensorInfo(state, tensor);
+    TensorInfo<unsigned long> srcInfo(state, src);
+    TensorInfo<unsigned long> indexInfo(state, index);
 
     RUN(unsigned long, -1)
   }
@@ -252,9 +252,9 @@ void THCudaTensor_scatter(THCState* state, THCudaTensor *tensor, int dim, THCuda
   if (THC_canUse32BitIndexMath(state, tensor) &&
       THC_canUse32BitIndexMath(state, src) &&
       THC_canUse32BitIndexMath(state, index)) {
-    TensorInfo<unsigned int> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned int> srcInfo(state, src, NoCollapseDims);
-    TensorInfo<unsigned int> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned int> tensorInfo(state, tensor);
+    TensorInfo<unsigned int> srcInfo(state, src);
+    TensorInfo<unsigned int> indexInfo(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -272,9 +272,9 @@ void THCudaTensor_scatter(THCState* state, THCudaTensor *tensor, int dim, THCuda
         break;
     }
   } else {
-    TensorInfo<unsigned long> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned long> srcInfo(state, src, NoCollapseDims);
-    TensorInfo<unsigned long> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned long> tensorInfo(state, tensor);
+    TensorInfo<unsigned long> srcInfo(state, src);
+    TensorInfo<unsigned long> indexInfo(state, index);
 
     RUN(unsigned long, -1)
   }
@@ -352,8 +352,8 @@ void THCudaTensor_scatterFill(THCState* state, THCudaTensor *tensor, int dim, TH
 
   if (THC_canUse32BitIndexMath(state, tensor) &&
       THC_canUse32BitIndexMath(state, index)) {
-    TensorInfo<unsigned int> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned int> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned int> tensorInfo(state, tensor);
+    TensorInfo<unsigned int> indexInfo(state, index);
 
     // Specialize for a small number of dimensions.
     switch (indexInfo.dims) {
@@ -371,8 +371,8 @@ void THCudaTensor_scatterFill(THCState* state, THCudaTensor *tensor, int dim, TH
         break;
     }
   } else {
-    TensorInfo<unsigned long> tensorInfo(state, tensor, NoCollapseDims);
-    TensorInfo<unsigned long> indexInfo(state, index, NoCollapseDims);
+    TensorInfo<unsigned long> tensorInfo(state, tensor);
+    TensorInfo<unsigned long> indexInfo(state, index);
 
     RUN(unsigned long, -1);
   }


### PR DESCRIPTION
The old non-contiguous indexSelect kernel was slow, and the code as checked in had a bug (the grid and block were swapped).

Although I cannot explain it by reading the code (it looked correct), we noticed memory corruption behavior from the old contiguous indexSelect kernel as well that only went away when we disabled the contiguous version internally.

I deleted the old kernels and rewrote them with something that is to my mind much simpler, and faster for all except the single outermost contiguous case (though in this case, not slow by much). For a very common case, index() of a 1-d tensor producing a 1-d result, the new kernel is much faster. Once this is accepted, I will replace the other index* kernels using a similar pattern.

The basic idea is that you can handle all dimensions except for the indexed dimension via normal indexing math in a tensor with the indexed dimension being size 1. The indexed dimension's offset (offset += index * stride[index_dim]) is then added in. The indexing is also specialized in the same way that the other pointwise etc. kernels are done as well.

I also added much more strenuous testing: multi-dimensions, large tensors, transposed/tensors with holes. I started to refactor the tensor construction code in test.lua, and will try and sprinkle this around in more tests in subsequent pull requests, since everywhere we should be testing with large + small, contig + non-contig + non-contig-with-holes tensors, especially when there are kernel specializations for various cases.

performance:

![image](https://cloud.githubusercontent.com/assets/1911637/11380733/e6d4c8e6-92c5-11e5-9151-2079935fa8a3.png)

code for the above perf numbers:
```
local function doTime(f)
   local timer = torch.Timer()
   cutorch.synchronize()
   timer:reset()

   f()
   cutorch.synchronize()
   print(timer:time().real * 1000)
end

local src = torch.CudaTensor(1000, 10, 1000):zero()
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(2, idx)
end)

local src = torch.CudaTensor(10, 1000, 1000):zero()
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(1000, 10, 1000):zero()
local idx = torch.linspace(1, 250, 250):mul(2):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(2, 5000, 1000):zero()
local idx = torch.LongTensor({2}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

-- transposed

local src = torch.CudaTensor(1000, 1000, 10):zero():transpose(2, 3)
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(2, idx)
end)

local src = torch.CudaTensor(10, 1000, 1000):zero():transpose(2, 3)
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(1000, 1000, 10):zero():transpose(2, 3)
local idx = torch.linspace(1, 250, 250):mul(2):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(2, 5000, 1000):zero():transpose(2, 3)
local idx = torch.LongTensor({2}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)


local src = torch.CudaTensor(10, 1000, 1000):zero():transpose(1, 2)
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(2, idx)
end)

local src = torch.CudaTensor(1000, 10, 1000):zero():transpose(1, 2)
local idx = torch.LongTensor({1, 3, 5, 7, 9}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(10, 1000, 1000):zero():transpose(1, 2)
local idx = torch.linspace(1, 250, 250):mul(2):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

local src = torch.CudaTensor(5000, 2, 1000):zero():transpose(1, 2)
local idx = torch.LongTensor({2}):cuda()
doTime(function()
      local out = src:index(1, idx)
end)

-- sparse 1-d

local src = torch.CudaTensor(10000000):zero()
local idx = torch.linspace(1, src:size(1) / 2, src:size(1) / 2):mul(2):cuda()
doTime(function()
      local out = src:index(1, idx)
end)
```