### PR TITLE
cutorch.synchronizeAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This new tensor type behaves exactly like a `torch.FloatTensor`, but has a coupl
 - `t:getDevice()` - Given a CudaTensor `t`, you can call :getDevice on it to find out the GPU ID on which the tensor memory is allocated.
 
 ###`cutorch.*` API
-- `cutorch.synchronize()` : All of the CUDA API is asynchronous (barring a few functions), which means that you can queue up operations. To wait for the operations to finish, you can issue `cutorch.synchronize()` in your code, when the code waits for all GPU operations on the current GPU to finish.
+- `cutorch.synchronize()` : All of the CUDA API is asynchronous (barring a few functions), which means that you can queue up operations. To wait for the operations to finish, you can issue `cutorch.synchronize()` in your code, when the code waits for all GPU operations on the current GPU to finish. WARNING: synchronizes the CPU host with respect to the current device (as per `cutorch.getDevice()`) only.
+- `cutorch.synchronizeAll()` : Same as `cutorch.synchronize()` except synchronizes the CPU host with all visible GPU devices in the system. Equivalent to calling `cutorch.synchronize()` once per each device.
 - `cutorch.setDevice(i)` : If one has multiple-GPUs, you can switch the default GPU (to allocate CUDA tensors and do operations). The GPU IDs are 1-indexed, so having 4 GPUs means, you can setDevice(1), setDevice(2), setDevice(3), setDevice(4).
 - `idx = cutorch.getDevice()` : Returns the currently set GPU device index.
 - `count = cutorch.getDeviceCount()` : Gets the number of available GPUs.


### PR DESCRIPTION
`cutorch.synchronize()` calls `cudaDeviceSynchronize()`, which synchronizes the host with respect to the **current device only**. The CUDA documentation itself is somewhat coy about this:

"Blocks until **the device** has completed all preceding requested tasks."

http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1g10e20b05a95f638a4071a655503df25d)

but validated by Paulius Micikevicius (formerly of NVIDIA) in slide 20 of http://www.nvidia.com/docs/IO/116711/sc11-multi-gpu.pdf and in other random googlings.

If you are running multi-GPU, you probably want to do this for all devices instead. This is implemented as `cutorch.synchronizeAll()`.

I could see this change being such that `cutorch.synchronize()` synchronizes all devices (which is what people probably think it does unfortunately), and we add a `cutorch.synchronizeCurrent()` which is what the current synchronize does, synchronizing just for the current device.
