### PR TITLE
top-k implementation + sort works for all cases now

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -479,6 +479,15 @@ wrap("sort",
         {name="index", default=lastdim(3)},
         {name="boolean", default=0}})
 
+wrap("topk",
+     cname("topk"),
+     {{name=Tensor, default=true, returned=true},
+        {name=Tensor, default=true, returned=true, noreadadd=true},
+        {name=Tensor},
+        {name="long", default=1},
+        {name="index", default=lastdim(3)},
+        {name="boolean", default=0},
+        {name="boolean", default=0}})
 
 do
    local Tensor = Tensor

--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -97,6 +97,7 @@ SET(src-cuda
   THCTensorScatterGather.cu
   THCApply.cu
   THCTensorSort.cu
+  THCTensorTopK.cu
   )
 
 CUDA_ADD_LIBRARY(THC SHARED ${src} ${src-cuda})
@@ -124,14 +125,18 @@ INSTALL(FILES
           THCTensorMath.h
           THCTensorConv.h
           THCTensorSort.h
+          THCTensorTopK.h
           THCApply.cuh
           THCReduce.cuh
           THCReduceAll.cuh
           THCReduceApplyUtils.cuh
+          THCAsmUtils.cuh
+          THCScanUtils.cuh
+          THCSortUtils.cuh
           THCAllocator.h
           THCDeviceUtils.cuh
           THCDeviceTensor.cuh
-          THCDeviceTensor-inl.cuh       
+          THCDeviceTensor-inl.cuh
           THCDeviceTensorUtils.cuh
           THCDeviceTensorUtils-inl.cuh
           THCGenerateAllTypes.h

--- a/lib/THC/THC.h
+++ b/lib/THC/THC.h
@@ -12,5 +12,6 @@
 #include "THCTensorMath.h"
 #include "THCTensorConv.h"
 #include "THCTensorSort.h"
+#include "THCTensorTopK.h"
 
 #endif

--- a/lib/THC/THCAsmUtils.cuh
+++ b/lib/THC/THCAsmUtils.cuh
@@ -1,0 +1,52 @@
+#ifndef THC_ASM_UTILS_INC
+#define THC_ASM_UTILS_INC
+
+// Collection of direct PTX functions
+
+__device__ __forceinline__
+unsigned int getBitfield(unsigned int val, int pos, int len) {
+  unsigned int ret;
+  asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
+  return ret;
+}
+
+__device__ __forceinline__
+unsigned int setBitfield(unsigned int val, unsigned int toInsert, int pos, int len) {
+  unsigned int ret;
+  asm("bfi.b32 %0, %1, %2, %3, %4;" :
+      "=r"(ret) : "r"(toInsert), "r"(val), "r"(pos), "r"(len));
+  return ret;
+}
+
+__device__ __forceinline__ int getLaneId() {
+  int laneId;
+  asm("mov.s32 %0, %laneid;" : "=r"(laneId) );
+  return laneId;
+}
+
+__device__ __forceinline__ unsigned getLaneMaskLt() {
+  unsigned mask;
+  asm("mov.u32 %0, %%lanemask_lt;" : "=r"(mask));
+  return mask;
+}
+
+__device__ __forceinline__ unsigned getLaneMaskLe() {
+  unsigned mask;
+  asm("mov.u32 %0, %%lanemask_le;" : "=r"(mask));
+  return mask;
+}
+
+__device__ __forceinline__ unsigned getLaneMaskGt() {
+  unsigned mask;
+  asm("mov.u32 %0, %%lanemask_gt;" : "=r"(mask));
+  return mask;
+}
+
+__device__ __forceinline__ unsigned getLaneMaskGe() {
+  unsigned mask;
+  asm("mov.u32 %0, %%lanemask_ge;" : "=r"(mask));
+  return mask;
+}
+
+
+#endif // THC_ASM_UTILS_INC

--- a/lib/THC/THCDeviceUtils.cuh
+++ b/lib/THC/THCDeviceUtils.cuh
@@ -12,4 +12,25 @@ __host__ __device__ __forceinline__ T THCCeilDiv(T a, T b) {
   return (a + b - 1) / b;
 }
 
+/**
+   Computes ceil(a / b) * b; i.e., rounds up `a` to the next highest
+   multiple of b
+*/
+template <typename T>
+__host__ __device__ __forceinline__ T THCRoundUp(T a, T b) {
+  return THCCeilDiv(a, b) * b;
+}
+
+/**
+ * For CC 3.5+, perform a load using __ldg
+ */
+template <typename T>
+__device__ __forceinline__ T doLdg(const T* p) {
+#if __CUDA_ARCH__ >= 350
+  return __ldg(p);
+#else
+  return *p;
+#endif
+}
+
 #endif // THC_DEVICE_UTILS_INC

--- a/lib/THC/THCScanUtils.cuh
+++ b/lib/THC/THCScanUtils.cuh
@@ -1,0 +1,116 @@
+#ifndef THC_SCAN_UTILS_INC
+#define THC_SCAN_UTILS_INC
+
+#include "THCAsmUtils.cuh"
+
+// Collection of in-kernel scan / prefix sum utilities
+
+// Inclusive prefix sum using shared memory
+template <typename T, bool KillWARDependency>
+__device__ void inclusivePrefixSum(T* smem, T in, T* out) {
+  // FIXME: this is a slow, simple implementation; need up/down sweep,
+  // prevent smem conflicts
+  smem[threadIdx.x] = in;
+
+  __syncthreads();
+
+  for (int offset = 1; offset < blockDim.x; offset *= 2) {
+    T val = 0;
+
+    if (threadIdx.x >= offset) {
+      val = smem[threadIdx.x - offset] + smem[threadIdx.x];
+    }
+
+    __syncthreads();
+    if (threadIdx.x >= offset) {
+      smem[threadIdx.x] = val;
+    }
+
+    __syncthreads();
+  }
+
+  *out = smem[threadIdx.x];
+
+  // Prevent write-after-read dependencies on smem usage above if necessary
+  if (KillWARDependency) {
+    __syncthreads();
+  }
+}
+
+// Exclusive prefix sum using shared memory
+template <typename T, bool KillWARDependency>
+__device__ void exclusivePrefixSum(T* smem, T in, T* out, T* carry) {
+  // FIXME: crappy implementation
+  // We kill write-after-read dependencies separately below, hence the `false`
+  inclusivePrefixSum<T, false>(smem, in, out);
+
+  *out -= in;
+  *carry = smem[blockDim.x - 1];
+
+  // Prevent write-after-read dependencies on smem usage above if necessary
+  if (KillWARDependency) {
+    __syncthreads();
+  }
+}
+
+// Inclusive prefix sum for binary vars using intra-warp voting +
+// shared memory
+template <typename T, bool KillWARDependency>
+__device__ void inclusiveBinaryPrefixSum(T* smem, bool in, T* out) {
+  // Within-warp, we use warp voting.
+  T vote = __ballot(in);
+  T index = __popc(getLaneMaskLe() & vote);
+  T carry = __popc(vote);
+
+  int warp = threadIdx.x / 32;
+
+  // Per each warp, write out a value
+  if (getLaneId() == 0) {
+    smem[warp] = carry;
+  }
+
+  __syncthreads();
+
+  // Sum across warps in one thread. This appears to be faster than a
+  // warp shuffle scan for CC 3.0+
+  if (threadIdx.x == 0) {
+    int current = 0;
+    for (int i = 0; i < blockDim.x / 32; ++i) {
+      T v = smem[i];
+      smem[i] += current;
+      current += v;
+    }
+  }
+
+  __syncthreads();
+
+  // load the carry from the preceding warp
+  if (warp >= 1) {
+    index += smem[warp - 1];
+  }
+
+  *out = index;
+
+  if (KillWARDependency) {
+    __syncthreads();
+  }
+}
+
+// Exclusive prefix sum for binary vars using intra-warp voting +
+// shared memory
+template <typename T, bool KillWARDependency>
+__device__ void exclusiveBinaryPrefixSum(T* smem, bool in, T* out, T* carry) {
+  inclusiveBinaryPrefixSum<T, false>(smem, in, out);
+
+  // Inclusive to exclusive
+  *out -= (T) in;
+
+  // The outgoing carry for all threads is the last warp's sum
+  *carry = smem[(blockDim.x / 32) - 1];
+
+  if (KillWARDependency) {
+    __syncthreads();
+  }
+}
+
+#endif // THC_SCAN_UTILS_INC

--- a/lib/THC/THCSortUtils.cuh
+++ b/lib/THC/THCSortUtils.cuh
@@ -1,0 +1,169 @@
+#ifndef THC_SORT_UTILS_INC
+#define THC_SORT_UTILS_INC
+
+#include "THCReduceApplyUtils.cuh"
+
+// Collection of kernel sort routines
+template <typename T>
+struct LTComp {
+  __device__ inline bool operator()(const T& a, const T& b) const {
+    return (a < b);
+  }
+};
+
+template <typename T>
+struct GTComp {
+  __device__ inline bool operator()(const T& a, const T& b) const {
+    return (a > b);
+  }
+};
+
+template <typename T>
+__device__ inline void swapVars(T& t1, T& t2) {
+  T tmp = t1;
+  t1 = t2;
+  t2 = tmp;
+}
+
+template <typename Comparator, typename K, typename V>
+__device__ inline void bitonicSwap(K& kA, V& vA, bool& validA,
+                                   K& kB, V& vB, bool& validB,
+                                   bool dir,
+                                   const Comparator& comp) {
+  // Invalid entries always sort to the end
+  bool swap = (comp(kA, kB) && validA) || !validB;
+  if (swap == dir) {
+    swapVars(kA, kB);
+    swapVars(vA, vB);
+    swapVars(validA, validB);
+  }
+};
+
+template <typename Comparator, typename K, typename V,
+          typename IndexType, int Power2SortSize>
+__device__ inline void bitonicSort(K keys[Power2SortSize],
+                                   V values[Power2SortSize],
+                                   bool valid[Power2SortSize],
+                                   const Comparator& comp) {
+#pragma unroll
+  for (unsigned int size = 2; size < Power2SortSize; size *= 2) {
+    bool flag = ((threadIdx.x & (size / 2)) != 0);
+
+#pragma unroll
+    for (unsigned int stride = size / 2; stride > 0; stride /= 2) {
+
+      // Single warp per slice is completely synchronous
+      if (Power2SortSize > 64) {
+        __syncthreads();
+      }
+
+      unsigned int pos = 2 * threadIdx.x - (threadIdx.x & (stride - 1));
+      bitonicSwap<Comparator, K, V>(
+        keys[pos], values[pos], valid[pos],
+        keys[pos + stride], values[pos + stride], valid[pos + stride],
+        flag, comp);
+    }
+  }
+
+#pragma unroll
+  for (unsigned int stride = Power2SortSize / 2; stride > 0; stride /= 2) {
+    // Single warp per slice is completely synchronous
+    if (Power2SortSize > 64) {
+      __syncthreads();
+    }
+
+    unsigned int pos = 2 * threadIdx.x - (threadIdx.x & (stride - 1));
+    bitonicSwap<Comparator, K, V>(
+      keys[pos], values[pos], valid[pos],
+      keys[pos + stride], values[pos + stride], valid[pos + stride],
+      false, comp);
+  }
+
+  // Single warp per slice is completely synchronous
+  if (Power2SortSize > 64) {
+    __syncthreads();
+  }
+}
+
+// Sorts (key, value) pairs (in different tensors) in-place; i.e.,
+// modifies the input `keys` and `values`
+template <typename K, typename V,
+          int KeyDims, int ValueDims,
+          typename Comparator, typename IndexType, int Power2SortSize>
+__global__ void
+bitonicSortKVInPlace(TensorInfo<IndexType> keys,
+                     IndexType keySlices,
+                     IndexType keySliceSize,
+                     IndexType keySliceStride,
+                     TensorInfo<IndexType> values,
+                     IndexType valueSliceStride,
+                     const Comparator& comp) {
+  // Find the slice of the tensor that we are sorting
+  const IndexType linearIndex = getLinearBlockId<IndexType>();
+  // Tiling the slices could have us be out of bounds, if there are a
+  // lot of slices to sort
+  if (linearIndex >= keySlices) {
+    return;
+  }
+
+  __shared__ K sharedKeys[Power2SortSize];
+  __shared__ V sharedValues[Power2SortSize];
+  __shared__ bool sharedValid[Power2SortSize];
+
+  const IndexType keyStartOffset =
+    IndexToOffset<IndexType, KeyDims>::get(linearIndex, keys);
+  const IndexType valueStartOffset =
+    IndexToOffset<IndexType, ValueDims>::get(linearIndex, values);
+
+  // If the sort size is 1, the data is already sorted
+  if (Power2SortSize == 1) {
+    return;
+  } else {
+    // Otherwise, each thread is responsible for loading and storing 2
+    // elements. The sort size is guaranteed to be >= 2
+    const int elem1 = threadIdx.x;
+    const int elem2 = threadIdx.x + (Power2SortSize / 2);
+
+    bool valid1 = (elem1 < keySliceSize);
+    K k1 = valid1 ?
+      keys.data[keyStartOffset + elem1 * keySliceStride] : (K) 0;
+    V v1 = valid1 ?
+      values.data[valueStartOffset + elem1 * valueSliceStride] : (V) 0;
+
+    sharedKeys[elem1] = k1;
+    sharedValues[elem1] = v1;
+    sharedValid[elem1] = valid1;
+
+    bool valid2 = (elem2 < keySliceSize);
+    K k2 = valid2 ?
+      keys.data[keyStartOffset + elem2 * keySliceStride] : (K) 0;
+    V v2 = valid2 ?
+      values.data[valueStartOffset + elem2 * valueSliceStride] : (V) 0;
+
+    sharedKeys[elem2] = k2;
+    sharedValues[elem2] = v2;
+    sharedValid[elem2] = valid2;
+
+    // Sort!
+    bitonicSort<Comparator, K, V, IndexType, Power2SortSize>(
+      sharedKeys, sharedValues, sharedValid, comp);
+
+    // elem1 values are always valid, since otherwise we would have
+    // chosen the next smallest power-of-2 for sorting
+    keys.data[keyStartOffset + elem1 * keySliceStride] =
+      sharedKeys[elem1];
+    values.data[valueStartOffset + elem1 * valueSliceStride] =
+      sharedValues[elem1];
+
+    if (valid2) {
+      // elem2 values might be out-of-range, if the data size we are
+      // sorting is not a power-of-2
+      keys.data[keyStartOffset + elem2 * keySliceStride] =
+        sharedKeys[elem2];
+      values.data[valueStartOffset + elem2 * valueSliceStride] =
+        sharedValues[elem2];
+    }
+  }
+}
+
+#endif // THC_SORT_UTILS_INC

--- a/lib/THC/THCTensorSort.h
+++ b/lib/THC/THCTensorSort.h
@@ -3,6 +3,15 @@
 
 #include "THCTensor.h"
 
+/* Performs an in-place sort of (keys, values). Only works for slice sizes
+   <= 2048 at the moment (slice size == size of keys/values dim `dim`) */
+THC_API void THCudaTensor_sortKeyValueInplace(THCState* state,
+                                              THCudaTensor* keys,
+                                              THCudaTensor* values,
+                                              int dim, int order);
+
+/* Performs an out-of-place sort of `input`, returning the per-slice indices
+   in `indices` and the sorted values in `sorted` */
 THC_API void THCudaTensor_sort(THCState* state,
                                THCudaTensor* sorted,
                                THCudaTensor* indices,

--- a/lib/THC/THCTensorTopK.cu
+++ b/lib/THC/THCTensorTopK.cu
@@ -1,0 +1,539 @@
+#include "THCReduceApplyUtils.cuh"
+#include "THCTensorMath.h"
+#include "THCTensorSort.h"
+#include "THCAsmUtils.cuh"
+#include "THCScanUtils.cuh"
+
+#if CUDA_VERSION >= 7000
+#include <thrust/system/cuda/execution_policy.h>
+#endif
+
+// Converts a float to an integer representation with the same
+// sorting; i.e., for floats f1, f2:
+// if f1 < f2 then convert(f1) < convert(f2)
+// We use this to enable radix selection of floating-point values.
+// This also gives a relative order for NaNs, but that's ok, as they
+// will all be adjacent
+struct FloatToSortedInt {
+  inline __host__ __device__ FloatToSortedInt() {}
+
+  inline __device__ unsigned int convert(float v) const {
+    unsigned int x = __float_as_int(v);
+    unsigned int mask = (x & 0x80000000) ? 0xffffffff : 0x80000000;
+
+    return (x ^ mask);
+  }
+
+  inline __device__ float deconvert(unsigned int v) const {
+    unsigned int mask = (v & 0x80000000) ? 0x80000000 : 0xffffffff;
+
+    return __int_as_float(v ^ mask);
+  }
+};
+
+// This function counts the distribution of all input values in a
+// slice we are selecting by radix digit at `radixDigitPos`, but only
+// those that pass the filter `((v & desiredMask) == desired)`.
+// This produces and broadcasts the seen counts for a single block only.
+// `smem` must have at least `RadixSize` elements.
+template <typename DataType, typename BitDataType,
+          typename IndexType, typename CountType,
+          typename RadixConverter, int RadixSize, int RadixBits>
+__device__ void countRadixUsingMask(const RadixConverter& conv,
+                                    CountType counts[RadixSize],
+                                    CountType* smem,
+                                    BitDataType desired,
+                                    BitDataType desiredMask,
+                                    int radixDigitPos,
+                                    IndexType sliceSize,
+                                    IndexType withinSliceStride,
+                                    DataType* data) {
+  // Clear out per-thread counts from a previous round
+#pragma unroll
+  for (int i = 0; i < RadixSize; ++i) {
+    counts[i] = 0;
+  }
+
+  if (threadIdx.x < RadixSize) {
+    smem[threadIdx.x] = 0;
+  }
+  __syncthreads();
+
+  // Scan over all the data. Upon a read, the warp will accumulate
+  // counts per each digit in the radix using warp voting.
+  for (IndexType i = threadIdx.x; i < sliceSize; i += blockDim.x) {
+    BitDataType val = conv.convert(doLdg(&data[i * withinSliceStride]));
+
+    bool hasVal = ((val & desiredMask) == desired);
+    unsigned int digitInRadix = getBitfield(val, radixDigitPos, RadixBits);
+
+#pragma unroll
+    for (unsigned int j = 0; j < RadixSize; ++j) {
+      bool vote = hasVal && (digitInRadix == j);
+      counts[j] += __popc(__ballot(vote));
+    }
+  }
+
+  // Now, for each warp, sum values
+  if (getLaneId() == 0) {
+#pragma unroll
+    for (unsigned int i = 0; i < RadixSize; ++i) {
+      atomicAdd(&smem[i], counts[i]);
+    }
+  }
+
+  __syncthreads();
+
+  // For each thread, read in the total counts
+#pragma unroll
+  for (unsigned int i = 0; i < RadixSize; ++i) {
+    counts[i] = smem[i];
+  }
+
+  __syncthreads();
+}
+
+// Over what radix we are selecting values
+#define RADIX_BITS 2 // digits are base-(2 ^ RADIX_BITS)
+#define RADIX_SIZE 4 // 2 ^ RADIX_BITS
+#define RADIX_MASK (RADIX_SIZE - 1)
+
+// This finds the unique value `v` that matches the pattern
+// ((v & desired) == desiredMask) in our sorted int format
+template <typename DataType, typename IndexType, typename RadixConverter>
+__device__ float findPattern(const RadixConverter& conv,
+                             DataType* smem,
+                             DataType* data,
+                             IndexType sliceSize,
+                             IndexType withinSliceStride,
+                             unsigned int desired,
+                             unsigned int desiredMask) {
+  if (threadIdx.x < 32) {
+    smem[threadIdx.x] = (DataType) 0;
+  }
+  __syncthreads();
+
+  // All threads participate in the loop, in order to sync on the flag
+  IndexType numIterations = THCRoundUp(sliceSize, (IndexType) blockDim.x);
+  for (IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+    bool inRange = (i < sliceSize);
+    DataType v = inRange ? doLdg(&data[i * withinSliceStride]) : (DataType) 0;
+
+    if (inRange && ((conv.convert(v) & desiredMask) == desired)) {
+      // There should not be conflicts if we are using findPattern,
+      // since the result is unique
+      smem[0] = (DataType) 1;
+      smem[1] = v; // can't use val as the flag, since it could be 0
+    }
+
+    __syncthreads();
+
+    DataType found = smem[0];
+    DataType val = smem[1];
+
+    __syncthreads();
+
+    // Check to see if a thread found the value
+    if (found != (DataType) 0) {
+      // all threads return this value
+      return val;
+    }
+  }
+
+  // should not get here
+  assert(false);
+  return (DataType) 0;
+}
+
+// Returns the top-Kth element found in the data using radix selection
+template <typename DataType, typename BitDataType, typename IndexType,
+          typename RadixConverter, bool Order>
+__device__ void radixSelect(const RadixConverter& conv,
+                            DataType* data,
+                            IndexType k,
+                            IndexType sliceSize,
+                            IndexType withinSliceStride,
+                            int* smem,
+                            DataType* topK) {
+  // Per-thread buckets into which we accumulate digit counts in our
+  // radix
+  int counts[RADIX_SIZE];
+
+  // We only consider elements x such that (x & desiredMask) == desired
+  // Initially, we consider all elements of the array, so the above
+  // statement is true regardless of input.
+  unsigned int desired = 0;
+  unsigned int desiredMask = 0;
+
+  // We are looking for the top kToFind-th element when iterating over
+  // digits; this count gets reduced by elimination when counting
+  // successive digits
+  int kToFind = k;
+
+  // We start at the most significant digit in our radix, scanning
+  // through to the least significant digit
+#pragma unroll
+  for (int digitPos = sizeof(BitDataType) * 8 - RADIX_BITS;
+       digitPos >= 0;
+       digitPos -= RADIX_BITS) {
+
+    // Count radix distribution for the current position and reduce
+    // across all threads
+    countRadixUsingMask<DataType, BitDataType,
+                        IndexType, int, RadixConverter,
+                        RADIX_SIZE, RADIX_BITS>(
+                          conv, counts, smem,
+                          desired, desiredMask, digitPos,
+                          sliceSize, withinSliceStride, data);
+
+    // All threads participate in the comparisons below to know the
+    // final result
+
+#define CHECK_RADIX(i)                                                  \
+    int count = counts[i];                                              \
+                                                                        \
+    /* All threads have the same value in counts here, so all */        \
+    /* threads will return from the function. */                        \
+    if (count == 1 && kToFind == 1) {                                   \
+      /* There is a unique answer. */                                   \
+      desired = setBitfield(desired, i, digitPos, RADIX_BITS);          \
+      desiredMask =                                                     \
+        setBitfield(desiredMask, RADIX_MASK, digitPos, RADIX_BITS);     \
+                                                                        \
+      /* The answer is now the unique element v such that: */           \
+      /* (v & desiredMask) == desired */                                \
+      /* However, we do not yet know what the actual element is. We */  \
+      /* need to perform a search through the data to find the */       \
+      /* element that matches this pattern. */                          \
+      *topK = findPattern<DataType, IndexType, RadixConverter>(         \
+        conv, (float*) smem, data, sliceSize,                           \
+        withinSliceStride, desired, desiredMask);                       \
+      return;                                                           \
+    }                                                                   \
+                                                                        \
+    if (count >= kToFind) {                                             \
+      desired = setBitfield(desired, i, digitPos, RADIX_BITS);          \
+      desiredMask =                                                     \
+        setBitfield(desiredMask, RADIX_MASK, digitPos, RADIX_BITS);     \
+                                                                        \
+      /* The top-Kth element v must now be one such that: */            \
+      /* (v & desiredMask == desired) */                                \
+      /* but we haven't narrowed it down; we must check the next */     \
+      /* least-significant digit */                                     \
+      break;                                                            \
+    }                                                                   \
+                                                                        \
+    kToFind -= count                                                    \
+
+    if (Order) {
+      // Process in descending order
+#pragma unroll
+      for (int i = RADIX_SIZE - 1; i >= 0; --i) {
+        CHECK_RADIX(i);
+      }
+    } else {
+      // Process in ascending order
+#pragma unroll
+      for (int i = 0; i < RADIX_SIZE; ++i) {
+        CHECK_RADIX(i);
+      }
+    }
+#undef CHECK_RADIX
+  } // end digitPos for
+
+  // There is no unique result, but there is a non-unique result
+  // matching `desired` exactly
+  *topK = conv.deconvert(desired);
+}
+
+template <typename IndexType, int Dim, bool Order>
+__global__ void gatherTopK(TensorInfo<IndexType> input,
+                           IndexType inputSliceSize,
+                           IndexType outputSliceSize, // aka `k`
+
+                           IndexType numInputSlices,
+                           IndexType inputWithinSliceStride,
+
+                           TensorInfo<IndexType> topK,
+                           IndexType numTopKSlices,
+                           IndexType topKWithinSliceStride,
+
+                           TensorInfo<IndexType> indices,
+                           IndexType indicesWithinSliceStride) {
+  // Indices are limited to integer fp precision, so counts can fit in
+  // int32, regardless of IndexType
+  __shared__ int smem[32]; // one per each warp, up to warp limit
+
+  IndexType slice = getLinearBlockId<IndexType>();
+  if (slice >= numInputSlices) {
+    return;
+  }
+
+  // Find the start offset for our slice
+  IndexType sliceStartIndex =
+    IndexToOffset<IndexType, Dim>::get(slice, input);
+  IndexType topKSliceStartIndex =
+    IndexToOffset<IndexType, Dim>::get(slice, topK);
+  IndexType indicesSliceStartIndex =
+    IndexToOffset<IndexType, Dim>::get(slice, indices);
+
+  float* inputSliceStart = &input.data[sliceStartIndex];
+  float* topKSliceStart = &topK.data[topKSliceStartIndex];
+  float* indicesSliceStart = &indices.data[indicesSliceStartIndex];
+
+  // Find the k-th highest element in our input
+  float topKValue = -1.0f;
+  radixSelect<float, unsigned int, IndexType, FloatToSortedInt, Order>(
+    FloatToSortedInt(),
+    inputSliceStart, outputSliceSize,
+    inputSliceSize, inputWithinSliceStride,
+    smem, &topKValue);
+
+  // Every value that is strictly less/greater than `pattern`
+  // (depending on sort dir) in sorted int format is in the top-K.
+  // The top-K value itself might not be unique.
+  //
+  // Since there are a variable number of elements that we see that
+  // are within the top-k, we don't know at what index to write out
+  // the resulting values.
+  // In order to get this, we perform an exclusive prefix sum of
+  // `hasTopK`. This will return the resulting index into which we
+  // need to write the result, if a thread has a result.
+
+  // All threads need to participate in the loop and the prefix sum,
+  // but not necessarily in the load; hence loop bounds being rounded
+  // up to a multiple of the block dim.
+  IndexType numIterations = THCRoundUp(inputSliceSize, (IndexType) blockDim.x);
+  IndexType writeIndexStart = 0;
+
+  for (IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+    bool inRange = (i < inputSliceSize);
+    float v =
+      inRange ? doLdg(&inputSliceStart[i * inputWithinSliceStride]) : 0.0f;
+    bool hasTopK;
+    if (Order) {
+      hasTopK = inRange && (v > topKValue);
+    } else {
+      hasTopK = inRange && (v < topKValue);
+    }
+
+    int index;
+    int carry;
+    exclusiveBinaryPrefixSum<int, true>(smem, hasTopK, &index, &carry);
+
+    if (hasTopK) {
+      int writeIndex = writeIndexStart + index;
+      assert(writeIndex < outputSliceSize);
+
+      IndexType topKOffset = writeIndex * topKWithinSliceStride;
+      IndexType indexOffset = writeIndex * indicesWithinSliceStride;
+
+      topKSliceStart[topKOffset] = v;
+      indicesSliceStart[indexOffset] = i + 1; // to Lua index
+    }
+
+    writeIndexStart += carry;
+  }
+
+  // We need to fill in the rest with actual == top-K values.
+  // The number that we need is outputSliceSize -
+  // writeIndexStart. There might be more than that number available,
+  // in which case we have to choose the first seen set. We do this
+  // via a prefix sum to calculate indices for writing results.
+  assert(outputSliceSize >= writeIndexStart);
+  IndexType topKRemaining = (outputSliceSize - writeIndexStart);
+
+  for (IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+    bool inRange = (i < inputSliceSize);
+    float v =
+      inRange ? doLdg(&inputSliceStart[i * inputWithinSliceStride]) : 0.0f;
+    bool hasTopK = inRange && (v == topKValue);
+
+    int index;
+    int carry;
+    exclusiveBinaryPrefixSum<int, true>(smem, hasTopK, &index, &carry);
+
+    if (hasTopK && index < topKRemaining) {
+      int writeIndex = writeIndexStart + index;
+      assert(writeIndex < outputSliceSize);
+
+      IndexType topKOffset = writeIndex * topKWithinSliceStride;
+      IndexType indexOffset = writeIndex * indicesWithinSliceStride;
+
+      topKSliceStart[topKOffset] = v;
+      indicesSliceStart[indexOffset] = i + 1; // to Lua index
+    }
+
+    if (carry >= topKRemaining) {
+      break;
+    }
+
+    topKRemaining -= carry;
+    writeIndexStart += carry;
+  }
+}
+
+#undef RADIX_BITS
+#undef RADIX_SIZE
+#undef RADIX_MASK
+
+THC_API void THCudaTensor_topk(THCState* state,
+                               THCudaTensor *topK,
+                               THCudaTensor *indices,
+                               THCudaTensor *input,
+                               long k, int dim, int dir, int sorted) {
+  THAssert(topK != NULL && indices != NULL && input != NULL);
+  THAssert(THCudaTensor_checkGPU(state, 3, topK, indices, input));
+  THCCheckTensorDims(state, topK, 2);
+  THCCheckTensorDims(state, indices, 2);
+  THCCheckTensorDims(state, input, 2);
+
+  int numDims = THCudaTensor_nDimension(state, input);
+  THArgCheck(dim >= 0 && dim < numDims, 3, "dim not in range");
+
+  long sliceSize = THCudaTensor_size(state, input, dim);
+  THArgCheck(k > 0 && k <= sliceSize, 2, "k not in range for dimension");
+
+  // We're using THCudaTensor to write out indices, so if the slice
+  // size that we're selecting has more elements than can be
+  // represented in fp32, warn the user
+  // FIXME: this isn't a real restriction of either our code or of
+  // Thrust, but we have to switch to a CUDA long tensor to support
+  // larger slice sizes. Otherwise the indices will contain garbage.
+  THArgCheck(sliceSize <= (long) FLOAT32_MAX_CONSECUTIVE_INT, 1,
+             "The dimension to be selected exceeds single-precision float "
+             "consecutive integer precision size (2^24), since float "
+             "is used for indices");
+
+  // Build the output size, which is the dim being selected set to
+  // size k
+  THLongStorage* topKSize = THCudaTensor_newSizeOf(state, input);
+  THLongStorage_set(topKSize, dim, k);
+  THCudaTensor_resize(state, topK, topKSize, NULL);
+  THCudaTensor_resize(state, indices, topKSize, NULL);
+  THLongStorage_free(topKSize);
+
+#define RUN_K(T, DIM, DIR)                                              \
+  gatherTopK<T, DIM, DIR>                                               \
+    <<<grid, block, 0, THCState_getCurrentStream(state)>>>(             \
+      inputInfo,                                                        \
+      sliceSize,                                                        \
+      k,                                                                \
+      inputSlices,                                                      \
+      /* The actual dimension that the k-selection is running in */     \
+      /* may have changed from collapseDims() */                        \
+      inputInfo.strides[collapseInputDim],                              \
+      topKInfo,                                                         \
+      topKSlices,                                                       \
+      topKInfo.strides[collapseTopKDim],                                \
+      indicesInfo,                                                      \
+      indicesInfo.strides[collapseIndicesDim])
+
+#define RUN_DIR(T, DIM)                         \
+  if (dir) {                                    \
+    RUN_K(T, DIM, true);                        \
+  } else {                                      \
+    RUN_K(T, DIM, false);                       \
+  }
+
+#define RUN_DIM(T)                              \
+  if (allDims == 1) {                           \
+    RUN_DIR(T, 1);                              \
+  } else if (allDims == 2) {                    \
+    RUN_DIR(T, 2);                              \
+  } else if (allDims == 3) {                    \
+    RUN_DIR(T, 3);                              \
+  } else {                                      \
+    RUN_DIR(T, -1);                             \
+  }
+
+#define RUN_T(T)                                                        \
+    TensorInfo<T> inputInfo(state, input);                              \
+    TensorInfo<T> topKInfo(state, topK);                                \
+    TensorInfo<T> indicesInfo(state, indices);                          \
+                                                                        \
+    /* We use these structures solely to find the offset to */          \
+    /* each slice we are operating on */                                \
+    inputInfo.sizes[dim] = 1;                                           \
+    topKInfo.sizes[dim] = 1;                                            \
+    indicesInfo.sizes[dim] = 1;                                         \
+                                                                        \
+    /* Collapse all other dims */                                       \
+    int collapseInputDim = inputInfo.collapseDims(dim);                 \
+    int collapseTopKDim = topKInfo.collapseDims(dim);                   \
+    int collapseIndicesDim = indicesInfo.collapseDims(dim);             \
+                                                                        \
+    long inputSlices = 1;                                               \
+    long topKSlices = 1;                                                \
+    for (int i = 0; i < numDims; ++i) {                                 \
+      inputSlices *= inputInfo.sizes[i];                                \
+      topKSlices *= topKInfo.sizes[i];                                  \
+    }                                                                   \
+                                                                        \
+    dim3 grid;                                                          \
+    if (!THC_getGridFromTiles(inputSlices, grid)) {                     \
+      THError("Slice to sort is too large");                            \
+    }                                                                   \
+                                                                        \
+    dim3 block(std::min(THCRoundUp(sliceSize, 32L), 1024L));            \
+                                                                        \
+    /* This is used as a template parameter to calculate indices. */    \
+    /* We only specialize it if all collapsed dim sizes are the */      \
+    /* same; otherwise, we use -1 which is the specialization */        \
+    /* parameter for arbitrary dimensions */                            \
+    int allDims = inputInfo.dims;                                       \
+    if (topKInfo.dims != allDims || indicesInfo.dims != allDims) {      \
+      allDims = -1;                                                     \
+    }                                                                   \
+                                                                        \
+    RUN_DIM(T);
+
+  // Based on required index size, run the algorithm with the
+  // appropriate index type
+  if (THC_canUse32BitIndexMath(state, input) &&
+      THC_canUse32BitIndexMath(state, topK) &&
+      THC_canUse32BitIndexMath(state, indices)) {
+    RUN_T(unsigned int);
+  } else {
+    RUN_T(unsigned long);
+  }
+#undef RUN_T
+#undef RUN_DIM
+#undef RUN_DIR
+#undef RUN_K
+
+  // Sort the results if the user wants them sorted, since our
+  // selection routine does not ensure sorting
+  if (sorted) {
+    // FIXME: the k/v inplace sort along slice only works for size <=
+    // 2048 at the moment
+    if (sliceSize <= 2048) {
+      // This avoids any memory allocations and performs all sorting
+      // work inplace along the slice
+      THCudaTensor_sortKeyValueInplace(state, topK, indices, dim, dir);
+    } else {
+      // Depend upon the backup sort that returns indices, which we
+      // can use in conjunction with gather to produce the original
+      // indices.
+      // This is not the most efficient implementation, especially since
+      // there are memory allocations performed here. If the user desires
+      // greater performance, they should torch.gather() the results
+      // themselves using the reported indices, providing previously
+      // allocated tensors to receive the results.
+      THCudaTensor* sortedTopK = THCudaTensor_new(state);
+      THCudaTensor* sortedIndices = THCudaTensor_new(state);
+      THCudaTensor_sort(state, sortedTopK, sortedIndices, topK, dim, dir);
+
+      THCudaTensor* sortedTopKIndices = THCudaTensor_new(state);
+
+      THCudaTensor_resizeAs(state, sortedTopKIndices, indices);
+      THCudaTensor_gather(state, sortedTopKIndices, indices, dim, sortedIndices);
+
+      THCudaTensor_freeCopyTo(state, sortedTopK, topK);
+      THCudaTensor_freeCopyTo(state, sortedTopKIndices, indices);
+      THCudaTensor_free(state, sortedIndices);
+    }
+  }
+
+  THCudaCheck(cudaGetLastError());
+}

--- a/lib/THC/THCTensorTopK.h
+++ b/lib/THC/THCTensorTopK.h
@@ -1,0 +1,14 @@
+#ifndef TH_CUDA_TENSOR_TOPK_INC
+#define TH_CUDA_TENSOR_TOPK_INC
+
+#include "THCTensor.h"
+
+/* Returns the set of all kth smallest (or largest) elements, depending */
+/* on `dir` */
+THC_API void THCudaTensor_topk(THCState* state,
+                               THCudaTensor* topK,
+                               THCudaTensor* indices,
+                               THCudaTensor* input,
+                               long k, int dim, int dir, int sorted);
+
+#endif


### PR DESCRIPTION
This pull request contains:
-an implementation of `values, indices = tensor:topk(k, dim, dir, sorted)` for CudaTensor via efficient radix selection.
-fixing `sort` for all possible inputs, regardless of size, stride, transpositions, holes, whatever.
-better testing for `sort`, and more re-factoring so that we can eventually use test tensors with holes/transpositions/multi-dimensions in all tests.

The top-k elements along slices defined by dimension `dim` are sorted are found and returned using radix selection (radix size of 4 is used here, it seems faster than radix-2 or radix-16 in my tests; the radix 2^k is possible where k is an even divisor of the total number of bits in the value being selected, so k=1, 2, 4, 8, 16, .., but there are 2^k buckets defined, so radix sizes of 2^1, 2^2, 2^4 are the only real feasible ones).

Radix selection is possible for floating-point numbers by bit manipulation, so that if float32 f1 < f2, then convert(f1) < convert(f2) where convert(f) produces an unsigned int and unsigned int comparison is used. Radix selection for top-k requires multiple passes over each input slice, but no scratch space (beyond registers or shared memory) are used in the process.

By default, the elements selected are returned unsorted. If sorting is desired, then a separate sort pass that performs the sorting of key/value pairs inplace is performed.

Because `topk()` uses the sorting mechanism, and I wanted a completely in-place implementation, I refactored the `sort()` code to sort on a key/value tensor pair. Even though there is an additional read and slightly more shared memory used for this sorting implementation, it is slightly faster/about the same/slightly slower than the old sort implementation for many sizes; not enough either way (+/- 3% or so) to be of real concern. The old `values, indices = t:sort(...)` API now uses this one (key, value) sort implementation so I don't need two implementations.

The old sort code was broken in many ways: failed on large numbers of slices of size > 2048, failed on non-contiguous index/sorted value result writes (since the result tensors can be non-contiguous as passed by `torch.sort(resval, resind, ...)` and other failure modes (tensor collapsing was broken, etc.). I now have a backup implementation that uses Thrust to perform a segmented vectorized sort that is the fallback case, and handles all possible sizes/dimensions/strides. In cases where the sorting dimension is not innermost contiguous or where any of the tensors (input, resval or resind) are not contiguous, memory allocations and copies are performed. What is important is that `sort()` now works for all possible inputs and no longer has any problems. The sort is very fast for cases where the slice to sort is <= 2048 elements, since all work is done in shared memory, and is reasonably fast for the Thrust backup when no memory is allocated.

Added new sort and top-k tests that test all manners of sizes and non-contiguous cases. The sort and top-k tests are slow, but there are lots of corner cases in the implementation (slices with size <= 2048 and > 2048 etc.) The cutorch test as a whole needs to get a lot more bulletproof and test many dimension sizes and strides, since with all of the template specialization in the cutorch code, there are many corner cases. Unfortunately to test many of them in a randomized fashion will require test.lua to take longer to run.

The sort and top-k code will work for compute capability 2.0+ (the only interesting intrinsic that I use is `__ballot()` for prefix sums of binary flags). I think CC 2.0+ is our minimum for cutorch anyways (1.x is ancient).

I did add a ldg feature that for 3.5+ code will use the __ldg() intrinsic, but will just use a normal deference for compute capability <3.5.