### PR TITLE
Adding cuBLAS matrix inverse

### DIFF
--- a/lib/THC/THCBlas.cu
+++ b/lib/THC/THCBlas.cu
@@ -234,3 +234,23 @@ void THCudaBlas_gemmBatched(THCState *state, char transa, char transb, long m, l
                                    &alpha, a, (int)lda, b, (int)ldb, &beta, c, (int)ldc,
                                    (int)batchCount));
 }
+
+/* Inverse */
+void THCudaBlas_getrf(THCState *state, int n, float **a, int lda, int *pivot, int *info, int batchSize) {
+  if( (n >= INT_MAX) || (lda >= INT_MAX) || (batchSize >= INT_MAX) )
+  {
+    THError("Cublas_getrf only supports n, lda, batchSize"
+            "with the bound [val] <= %d", INT_MAX);
+  }
+  THCublasCheck(cublasSgetrfBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, info, batchSize));
+}
+
+void THCudaBlas_getri(THCState *state, int n, const float **a, int lda, int *pivot, float **c, int ldc, int *info, int batchSize) {
+
+  if( (n >= INT_MAX) || (lda >= INT_MAX)|| (ldc >= INT_MAX) || (batchSize >= INT_MAX) )
+  {
+    THError("Cublas_getrf only supports n, lda, ldc, batchSize"
+            "with the bound [val] <= %d", INT_MAX);
+  }
+  THCublasCheck(cublasSgetriBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, c, ldc, info, batchSize));
+}

--- a/lib/THC/THCBlas.h
+++ b/lib/THC/THCBlas.h
@@ -20,4 +20,8 @@ THC_API void THCudaBlas_gemmBatched(THCState *state, char transa, char transb, l
                                     float alpha, const float *a[], long lda, const float *b[], long ldb,
                                     float beta, float *c[], long ldc, long batchCount);
 
+/* Inverse */
+THC_API void THCudaBlas_getrf(THCState *state, int n, float **a, int lda, int *pivot, int *info, int batchSize);
+THC_API void THCudaBlas_getri(THCState *state, int n, const float **a, int lda, int *pivot, float **c, int ldc, int *info, int batchSize);
+
 #endif

--- a/test/test.lua
+++ b/test/test.lua
@@ -1558,6 +1558,13 @@ function test.ger()
    end
 end
 
+function test.inverse()
+   local a = torch.randn(5, 5)
+   local i1 = torch.inverse(a)
+   local i2 = torch.inverse(a:cuda())
+   tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong inverse answer")
+end
+
 if cutorch.magma then
    function test.gesv()
       local a = torch.Tensor(5, 5):uniform(-1, 1)
@@ -1636,12 +1643,6 @@ if cutorch.magma then
       tester:assertle((v*v:t() - torch.eye(a:size(2)):cuda()):abs():max(), 1e-6, "svd: v should be unitary")
    end
 
-   function test.inverse()
-      local a = torch.randn(5, 5)
-      local i1 = torch.inverse(a)
-      local i2 = torch.inverse(a:cuda())
-      tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong inverse answer")
-   end
 
    function test.potri()
       local A = torch.Tensor{


### PR DESCRIPTION
torch.inverse requires MAGMA. This adds cuBLAS getrf and getri bindings s.t. we can compute matrix inverse directly with cuBLAS without MAGMA.

moved the inverse test outside of cutorch.magma block