### PR TITLE
Turn cutorch heap tracking back on (removed accidentally in df46369)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -49,4 +49,8 @@ function cutorch.createCudaHostTensor(...)
    return torch.FloatTensor(storage, 1, size:storage())
 end
 
+-- remove this line to disable automatic cutorch heap-tracking
+-- for garbage collection
+cutorch.setHeapTracking(true)
+
 return cutorch


### PR DESCRIPTION
Fixes https://github.com/karpathy/neuraltalk2/issues/52.