### PR TITLE
Fixed MAKE_C_FLAGS propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ FIND_PACKAGE(CUDA 5.5 REQUIRED)
 FIND_PACKAGE(MAGMA)
 
 IF (NOT WIN32)
-SET(CMAKE_C_FLAGS "-std=c99 -Werror=implicit-function-declaration")
+SET(CMAKE_C_FLAGS "-std=c99 -Werror=implicit-function-declaration ${CMAKE_C_FLAGS}")
 ENDIF (NOT WIN32)
 
 INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})


### PR DESCRIPTION
Setting MAKE_C_FLAGS should always add, not overwrite, flags.
In this particular case, Android make fails as the --sysroot argument gets lost.