### PR TITLE
add setShowAllocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This new tensor type behaves exactly like a `torch.FloatTensor`, but has a coupl
 - `idx = cutorch.getDevice()` : Returns the currently set GPU device index.
 - `count = cutorch.getDeviceCount()` : Gets the number of available GPUs.
 - `freeMemory, totalMemory = cutorch.getMemoryUsage(devID)` : Gets the total and free memory in bytes for the given device ID.
+-  setShowAllocations([true|false])  : if true, prints a message each time CUDA allocation occurs
 - `cutorch.seed([devID])` - Sets and returns a random seed for the current or specified device.
 - `cutorch.seedAll()` - Sets and returns a random seed for all available GPU devices.
 - `cutorch.initialSeed([devID])` - Returns the seed for the current or specified device

--- a/init.c
+++ b/init.c
@@ -691,6 +691,21 @@ static int cutorch_getMemoryUsage(lua_State *L) {
   return 2;
 }
 
+static int cutorch_setShowAllocations(lua_State *L)
+{
+  THCState *state = cutorch_getstate(L);
+  int showAllocations = (int)luaT_checkboolean(L,1);
+  if(showAllocations != 0) {
+    printf("Activating showAllocations\n");
+    state->showAllocations = 1;
+  } else {
+    printf("Disabling showAllocations\n");
+    state->showAllocations = 0;
+  }
+
+  return 0;
+}
+
 static int cutorch_setDevice(lua_State *L)
 {
   THCState *state = cutorch_getstate(L);
@@ -909,6 +924,7 @@ static const struct luaL_Reg cutorch_stuff__ [] = {
   {"setKernelPeerToPeerAccess", cutorch_setKernelPeerToPeerAccess},
   {"getKernelPeerToPeerAccess", cutorch_getKernelPeerToPeerAccess},
   {"getDeviceProperties", cutorch_getDeviceProperties},
+  {"setShowAllocations", cutorch_setShowAllocations},
   {"getMemoryUsage", cutorch_getMemoryUsage},
   {"setDevice", cutorch_setDevice},
   {"seed", cutorch_seed},

--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -31,6 +31,8 @@ void THCudaInit(THCState* state)
   state->numUserStreams = 0;
   state->numUserBlasHandles = 0;
 
+  state->showAllocations = 0;
+
   /* Enable P2P access between all pairs, if possible */
   THCudaEnablePeerToPeerAccess(state);
 

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -92,6 +92,8 @@ typedef struct THCState
   void *cutorchGCData;
   long heapSoftmax;
   long heapDelta;
+
+  int showAllocations;
 } THCState;
 
 THC_API void THCudaInit(THCState* state);

--- a/lib/THC/generic/THCStorage.c
+++ b/lib/THC/generic/THCStorage.c
@@ -60,6 +60,8 @@ THCStorage* THCStorage_(newWithSize)(THCState *state, long size)
   {
     THCStorage *storage = (THCStorage*)THAlloc(sizeof(THCStorage));
 
+    if(state->showAllocations) printf("Allocating CUDA storage %li bytes\n", size * sizeof(real));
+
     // update heap *before* attempting malloc, to free space for the malloc
     THCHeapUpdate(state, size * sizeof(real));
     cudaError_t err =
@@ -154,6 +156,7 @@ void THCStorage_(free)(THCState *state, THCStorage *self)
   if (THAtomicDecrementRef(&self->refcount))
   {
     if(self->flag & TH_STORAGE_FREEMEM) {
+      if(state->showAllocations) printf("Freeing CUDA storage %li bytes\n", self->size * sizeof(real));
       THCHeapUpdate(state, -self->size * sizeof(real));
       THCudaCheck(THCudaFree(state, self->data));
     }

--- a/lib/THC/generic/THCStorage.cu
+++ b/lib/THC/generic/THCStorage.cu
@@ -23,6 +23,8 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, long size)
   if(size == 0)
   {
     if(self->flag & TH_STORAGE_FREEMEM) {
+      if(state->showAllocations) printf("Free CUDA storage %li bytes\n",
+        self->size * sizeof(real));
       THCudaCheck(THCudaFree(state, self->data));
       THCHeapUpdate(state, -self->size * sizeof(real));
     }
@@ -34,6 +36,8 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, long size)
     real *data = NULL;
     // update heap *before* attempting malloc, to free space for the malloc
     THCHeapUpdate(state, size * sizeof(real));
+    if(state->showAllocations) printf("Alloc CUDA storage %li bytes\n",
+      size * sizeof(real));
     cudaError_t err = THCudaMalloc(state, (void**)(&data), size * sizeof(real));
     if(err != cudaSuccess) {
       THCHeapUpdate(state, -size * sizeof(real));
@@ -46,6 +50,8 @@ void THCStorage_(resize)(THCState *state, THCStorage *self, long size)
                                   THMin(self->size, size) * sizeof(real),
                                   cudaMemcpyDeviceToDevice,
                                   THCState_getCurrentStream(state)));
+      if(state->showAllocations) printf("Free CUDA storage %li bytes\n",
+        self->size * sizeof(real));
       THCudaCheck(THCudaFree(state, self->data));
       THCHeapUpdate(state, -self->size * sizeof(real));
     }


### PR DESCRIPTION
This allows showing any CUDA allocations and frees, to ensure that they are not being done inadvertently.

Use like:

```
require 'cutorch'

cutorch.setShowAllocations(1)

print('create tensor')
a = torch.CudaTensor(3,2):uniform()

print('print a')
print('a', a)

print('add 1 to a')
a:add(1)

print('contiguous tensor')
a:contiguous()

print('reshape tensor')
a:reshape(2,3)

print('reshape tensor')
a:reshape(2,3)
```

Output:
```
Activating showAllocations
create tensor
Alloc CUDA storage 24 bytes
print a
a        0.8305  0.9278
 0.4579  0.3724
 0.6263  0.6756
[torch.CudaTensor of size 3x2]

add 1 to a
contiguous tensor
reshape tensor
Alloc CUDA storage 24 bytes
reshape tensor
Alloc CUDA storage 24 bytes
Freeing CUDA storage 24 bytes
Freeing CUDA storage 24 bytes
Freeing CUDA storage 24 bytes
```

