### PR TITLE
autotranspose to stride 1 is final dimension, in apply1

### DIFF
--- a/lib/THC/THCApply.cuh
+++ b/lib/THC/THCApply.cuh
@@ -197,6 +197,14 @@ bool THCudaTensor_pointwiseApply1(THCState* state,
   // additional overhead.
   if (THC_canUse32BitIndexMath(state, a)) {
     TensorInfo<unsigned int> aInfo(state, a);
+
+    // if the final dimension is not the one with stride 1, swap with the one that is,
+    // if such a dimension exists
+    int smallestStrideDim = aInfo.getSmallestStrideDim();
+    if(smallestStrideDim != -1 &&
+        smallestStrideDim != aInfo.dims - 1) {
+      aInfo.transpose(smallestStrideDim, aInfo.dims - 1);
+    }
     aInfo.collapseDims();
 
     HANDLE_A_CASE(unsigned int, aInfo.dims);

--- a/test/test.lua
+++ b/test/test.lua
@@ -998,6 +998,28 @@ for _,name in ipairs({"log", "log1p", "exp",
 
 end
 
+function test.transposeInvariant()
+  -- since apply1 modifies the transpose to optimize memory access
+  -- patterns, we should check this doesnt break anything
+  -- so, we create a tensor, clone it, and do eg tanh both
+  -- transposed, and non-transposed, and check results are identical
+   local sz1 = chooseInt(minsize, maxsize)
+   local sz2 = chooseInt(minsize, maxsize)
+   local a = torch.CudaTensor(sz1, sz2):uniform()
+   local a2 = a:clone()
+
+   a:tanh()
+
+   a2 = a2:t()
+   a2:tanh()
+   a2 = a2:t()
+
+   tester:assert(isEqual(
+      (a - a2):abs():max(),
+      0),
+      "Divergent results between transpose and non-transpose")
+end
+
 function test.atan2(fn)
    local sz1 = chooseInt(minsize, maxsize)
    local sz2 = chooseInt(minsize, maxsize)


### PR DESCRIPTION
Addresses https://github.com/torch/cutorch/issues/323

Test case for timings:

```
require 'sys'
require 'cutorch'

local side = 8 * 1024
local time = nil
for it=1,3 do
  print('==== it', it, '==============')

  a = torch.CudaTensor(side, side)
  collectgarbage()
  a = a:t()
  cutorch.synchronize()
  sys.tic()
  -- start, ie assume the tensor arrives transposed
  a:tanh()
  cutorch.synchronize()
  time = sys.toc()
  print('tanh without re-transpose, size', side * side * 4 / 1024 /1024, 'MB =', time, 'seconds')

  a = torch.CudaTensor(side, side)
  collectgarbage()
  a = a:t()
  cutorch.synchronize()
  sys.tic()
  -- start, ie assume the tensor arrives transposed
  a = a:t()
  a:tanh()
  a = a:t()
  cutorch.synchronize()
  time = sys.toc()
  print('tanh with re-transpose, size', side * side * 4 / 1024 /1024, 'MB =', time, 'seconds')

  a = torch.CudaTensor(side, side)
  collectgarbage()
  a = a:t()
  cutorch.synchronize()
  sys.tic()
  -- start, ie assume the tensor arrives transposed
  a:neg()
  cutorch.synchronize()
  time = sys.toc()
  print('neg without re-transpose, size', side * side * 4 / 1024 /1024, 'MB =', time, 'seconds')

  a = torch.CudaTensor(side, side)
  collectgarbage()
  a = a:t()
  cutorch.synchronize()
  sys.tic()
  -- start, ie assume the tensor arrives transposed
  a = a:t()
  a:neg()
  a = a:t()
  cutorch.synchronize()
  time = sys.toc()
  print('neg with re-transpose, size', side * side * 4 / 1024 /1024, 'MB =', time, 'seconds')
end
```

Output, on K520, before PR:
```
tanh without re-transpose, size 256     MB =    0.17799401283264        seconds
tanh with re-transpose, size    256     MB =    0.0059909820556641      seconds
neg without re-transpose, size  256     MB =    0.17719101905823        seconds
neg with re-transpose, size     256     MB =    0.0050539970397949      seconds
```

After PR:
```
tanh without re-transpose, size 256     MB =    0.0051589012145996      seconds
tanh with re-transpose, size    256     MB =    0.0051488876342773      seconds
neg without re-transpose, size  256     MB =    0.0050041675567627      seconds
neg with re-transpose, size     256     MB =    0.0050230026245117      seconds
```
