### PR TITLE
Fix indexing bug in indexCopy, indexAdd, indexFill in Cutorch + tests

### DIFF
--- a/lib/THC/THCTensorIndex.cu
+++ b/lib/THC/THCTensorIndex.cu
@@ -8,253 +8,589 @@
 #include "THCDeviceUtils.cuh"
 #include <algorithm> // for std::min
 
-__global__ void THCudaTensor_kernel_indexFill(
-   float *tensor, long* stride, float *index, long src_nDim,
-   int dim, long idx_size, long tensor_size, long size_dim, float val
-)
-{
-  int thread_idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+// We prefer this kernel to avoid reloading index points if the number
+// of indices is a small number.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is large, then the
+// indexCopyLargeIndex kernel is a better choice to increase
+// parallelism.
+template <typename IndexType, int DstDim, int SrcDim, int IdxDim>
+__global__ void indexCopySmallIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> src,
+                                      TensorInfo<IndexType> indices,
+                                      int dstCopyDim,
+                                      int srcCopyDim,
+                                      IndexType innerSize,
+                                      long dstCopyDimSize) {
+  // In order to avoid reloading the index that we are copying, load
+  // it once to handle all of the points that are being selected, so
+  // it can be reused as much as possible. This kernel is chosen when
+  // this is a good choice (small number of chosen indices), since
+  // re-accessing indices in addition to src elements can be slow.
+  for (IndexType srcIndex = 0; srcIndex < indices.sizes[0]; ++srcIndex) {
+    // Lua indices begin at 1
+    IndexType dstIndex =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(srcIndex, indices)] - 1;
 
-  long flat_size = tensor_size / idx_size;
+    if (dstIndex < dstCopyDimSize) {
+      // We stride over the output ignoring the indexed dimension
+      // (innerSize), whose offset calculation is handled differently
+      for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+           linearIndex < innerSize;
+           linearIndex += gridDim.x * blockDim.x) {
+        IndexType dstOffset =
+          IndexToOffset<IndexType, DstDim>::get(linearIndex, dst);
 
-  if (thread_idx < flat_size)
-  {
-    long coeff = 0;
-    for (int i=0; i<idx_size; i++)
-    {
-      int leftover = thread_idx;
-      int srcIdx = 0;
-      for (int d=0; d<src_nDim; d++)
-      {
-        if (d < dim)
-        {
-          coeff = leftover / (stride[d] / size_dim);
-          leftover -= coeff * (stride[d] / size_dim);
-          srcIdx += coeff * stride[d];
-        }
-        else if (d > dim)
-        {
-          coeff = leftover / stride[d];
-          leftover -= coeff * stride[d];
-          srcIdx += coeff * stride[d];
-        }
+        dstOffset += dstIndex * dst.strides[dstCopyDim];
+
+        IndexType srcOffset =
+          IndexToOffset<IndexType, SrcDim>::get(linearIndex, src);
+        srcOffset += srcIndex * src.strides[srcCopyDim];
+
+        dst.data[dstOffset] = src.data[srcOffset];
       }
-        tensor[srcIdx + (long)((index[i])-1)*stride[dim]] = val;
     }
   }
 }
 
-__global__ void THCudaTensor_kernel_indexCopy(
-   float *res, float *src, long* res_stride, float *index,
-   long res_nDim, int dim, long idx_size, long src_size, long size_dim
-)
-{
-  int thread_idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+// We prefer this kernel to balance parallelism across index points,
+// if there are a large number of indices.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is small, then the
+// indexCopySmallIndex kernel is a better choice to reduce memory
+// accesses.
+template <typename IndexType, int DstDim, int SrcDim, int IdxDim>
+__global__ void indexCopyLargeIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> src,
+                                      TensorInfo<IndexType> indices,
+                                      int dstCopyDim,
+                                      int srcCopyDim,
+                                      IndexType innerSize,
+                                      long dstCopyDimSize) {
+  // We stride over the output including the indexed dimension
+  // (totalSize), and calculate the destination index point based on that
+  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+       linearIndex < innerSize * indices.sizes[0];
+       linearIndex += gridDim.x * blockDim.x) {
+    IndexType srcIndex = linearIndex / innerSize;
+    IndexType elementInSlice = linearIndex % innerSize;
 
-  long flat_size = src_size / idx_size;
+    // Lua indices begin at 1
+    IndexType dstIndex =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(srcIndex, indices)] - 1;
 
-  if (thread_idx < flat_size)
-  {
-    long coeff = 0;
-    for (int i=0; i<idx_size; i++)
-    {
-      int leftover = thread_idx;
-      int targetIdx = 0;
-      int resIdx = 0;
-      for (int d=0; d<res_nDim; d++)
-      {
-        if (d < dim)
-        {
-          long stride_d = res_stride[d] / size_dim;
-          coeff = leftover / stride_d;
-          leftover -= coeff * stride_d;
-          targetIdx += coeff * stride_d * idx_size;
-          resIdx += coeff * res_stride[d];
-        }
-        else if (d > dim)
-        {
-          coeff = leftover / res_stride[d];
-          leftover -= coeff * res_stride[d];
-          targetIdx += coeff * res_stride[d];
-          resIdx += coeff * res_stride[d];
-        }
-      }
-      res[resIdx + ((long)(index[i])-1)*res_stride[dim]] = src[targetIdx + i*res_stride[dim]];
+    if (dstIndex < dstCopyDimSize) {
+      IndexType dstOffset =
+        IndexToOffset<IndexType, DstDim>::get(elementInSlice, dst);
+      dstOffset += dstIndex * dst.strides[dstCopyDim];
+
+      IndexType srcOffset =
+        IndexToOffset<IndexType, SrcDim>::get(elementInSlice, src);
+      srcOffset += srcIndex * src.strides[srcCopyDim];
+
+      dst.data[dstOffset] = src.data[srcOffset];
     }
   }
 }
 
-__global__ void THCudaTensor_kernel_indexAdd(
-   float *res, float *src, long* res_stride, float *index,
-   long res_nDim, int dim, long idx_size, long src_size, long size_dim
-)
+void THCudaTensor_indexCopy_long(THCState *state, THCudaTensor *dst, int dim, THLongTensor *indices, THCudaTensor *src)
 {
-  int thread_idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+  THAssert(THCudaTensor_checkGPU(state, 2, dst, src));
 
-  long flat_size = src_size / idx_size;
+  THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
+  THCudaTensor_copyLong(state, indices_, indices);
 
-  if (thread_idx < flat_size)
-  {
-    long coeff = 0;
-    for (int i=0; i<idx_size; i++)
-    {
-      int leftover = thread_idx;
-      int targetIdx = 0;
-      int resIdx = 0;
-      for (int d=0; d<res_nDim; d++)
-      {
-        if (d < dim)
-        {
-          long stride_d = res_stride[d] / size_dim;
-          coeff = leftover / stride_d;
-          leftover -= coeff * stride_d;
-          targetIdx += coeff * stride_d * idx_size;
-          resIdx += coeff * res_stride[d];
-        }
-        else if (d > dim)
-        {
-          coeff = leftover / res_stride[d];
-          leftover -= coeff * res_stride[d];
-          targetIdx += coeff * res_stride[d];
-          resIdx += coeff * res_stride[d];
-        }
+  THCudaTensor_indexCopy(state, dst, dim, indices_, src);
+
+  THCudaTensor_free(state, indices_);
+}
+
+void THCudaTensor_indexCopy(THCState *state, THCudaTensor *dst, int dim, THCudaTensor *indices, THCudaTensor *src)
+{
+  THAssert(THCudaTensor_checkGPU(state, 3, dst, indices, src));
+
+  THCCheckTensorDims(state, dst, 2);
+  THCCheckTensorDims(state, src, 5);
+  THCCheckTensorDims(state, indices, 4);
+
+  long numIndices = THCudaTensor_nElement(state, indices);
+
+  long srcDims = THCudaTensor_nDimension(state, src);
+  cudaStream_t stream = THCState_getCurrentStream(state);
+
+  THArgCheck(THCudaTensor_nDimension(state, indices) == 1, 3,
+             "expecting vector of indices");
+  THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
+  THArgCheck(srcDims > 0, 2, "Source tensor is empty");
+  THArgCheck(numIndices == src->size[dim], 4, "length of src.size[dim] is not equal to length of indices");
+
+  int indContig = THCudaTensor_isContiguous(state, indices);
+
+  // The `src` is partitioned into two parts:
+  // -the size of each slice we are indexing, which is the
+  // total size of the tensor ignoring dimension `dim`;
+  // -the number of indices we are choosing, which is the total size
+  // of the tensor `indices`.
+  long srcTotalSize = THCudaTensor_nElement(state, src);
+  long dstCopyDimSize = THCudaTensor_size(state, dst, dim);
+  long sliceSize = srcTotalSize / numIndices;
+
+  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+
+#define SMALL_INDEX(TYPE, DST_DIM, SRC_DIM, IDX_DIM)            \
+  indexCopySmallIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>        \
+    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(           \
+      dstInfo, srcInfo, indicesInfo,                            \
+      dstCopyDim, srcCopyDim, sliceSize, dstCopyDimSize);
+
+#define LARGE_INDEX(TYPE, DST_DIM, SRC_DIM, IDX_DIM)            \
+  indexCopyLargeIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>        \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(           \
+      dstInfo, srcInfo, indicesInfo,                            \
+      dstCopyDim, srcCopyDim, sliceSize, dstCopyDimSize);
+
+  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, 128L), (long)(mpc * 8)));
+  dim3 smallIndexBlock(std::min(sliceSize, 128L));
+
+  dim3 largeIndexGrid(std::min(THCCeilDiv(srcTotalSize, 128L), (long)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(srcTotalSize, 128L));
+
+  if (THC_canUse32BitIndexMath(state, dst) &&
+      THC_canUse32BitIndexMath(state, src) &&
+      THC_canUse32BitIndexMath(state, indices)) {
+    TensorInfo<unsigned int> dstInfo(state, dst);
+    int dstCopyDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstCopyDim] = 1;
+
+    TensorInfo<unsigned int> srcInfo(state, src);
+    int srcCopyDim = srcInfo.collapseDims(dim);
+    srcInfo.sizes[srcCopyDim] = 1;
+
+    TensorInfo<unsigned int> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
+
+    // A reasonable choice for when to have each thread iterate over
+    // indices to choose
+    if (numIndices <= 16) {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        SMALL_INDEX(unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        SMALL_INDEX(unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        SMALL_INDEX(unsigned int, 3, 3, -2);
+      } else {
+        SMALL_INDEX(unsigned int, -1, -1, -1);
       }
-      atomicAdd(&res[resIdx + ((long)(index[i])-1)*res_stride[dim]], src[targetIdx + i*res_stride[dim]]);
+    } else {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        LARGE_INDEX(unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        LARGE_INDEX(unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        LARGE_INDEX(unsigned int, 3, 3, -2);
+      } else {
+        LARGE_INDEX(unsigned int, -1, -1, -1);
+      }
+    }
+  } else {
+    TensorInfo<unsigned long> dstInfo(state, dst);
+    int dstCopyDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstCopyDim] = 1;
+
+    TensorInfo<unsigned long> srcInfo(state, src);
+    int srcCopyDim = srcInfo.collapseDims(dim);
+    srcInfo.sizes[srcCopyDim] = 1;
+
+    TensorInfo<unsigned long> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
+
+    LARGE_INDEX(unsigned long, -1, -1, -1);
+  }
+
+#undef SMALL_INDEX
+#undef LARGE_INDEX
+}
+
+// We prefer this kernel to avoid reloading index points if the number
+// of indices is a small number.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is large, then the
+// indexAddLargeIndex kernel is a better choice to increase
+// parallelism.
+template <typename IndexType, int DstDim, int SrcDim, int IdxDim>
+__global__ void indexAddSmallIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> src,
+                                      TensorInfo<IndexType> indices,
+                                      int dstAddDim,
+                                      int srcAddDim,
+                                      IndexType innerSize,
+                                      long dstAddDimSize) {
+  // In order to avoid reloading the index that we are copying, load
+  // it once to handle all of the points that are being selected, so
+  // it can be reused as much as possible. This kernel is chosen when
+  // this is a good choice (small number of chosen indices), since
+  // re-accessing indices in addition to src elements can be slow.
+  for (IndexType srcIndex = 0; srcIndex < indices.sizes[0]; ++srcIndex) {
+    // Lua indices begin at 1
+    IndexType dstIndex =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(srcIndex, indices)] - 1;
+
+    if (dstIndex < dstAddDimSize) {
+      // We stride over the output ignoring the indexed dimension
+      // (innerSize), whose offset calculation is handled differently
+      for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+           linearIndex < innerSize;
+           linearIndex += gridDim.x * blockDim.x) {
+        IndexType dstOffset =
+          IndexToOffset<IndexType, DstDim>::get(linearIndex, dst);
+        dstOffset += dstIndex * dst.strides[dstAddDim];
+
+        IndexType srcOffset =
+          IndexToOffset<IndexType, SrcDim>::get(linearIndex, src);
+        srcOffset += srcIndex * src.strides[srcAddDim];
+
+        atomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
+      }
     }
   }
 }
 
-void THCudaTensor_indexCopy_long(THCState *state, THCudaTensor *res_, int dim, THLongTensor *indices, THCudaTensor *src)
+// We prefer this kernel to balance parallelism across index points,
+// if there are a large number of indices.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is small, then the
+// indexAddSmallIndex kernel is a better choice to reduce memory
+// accesses.
+template <typename IndexType, int DstDim, int SrcDim, int IdxDim>
+__global__ void indexAddLargeIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> src,
+                                      TensorInfo<IndexType> indices,
+                                      int dstAddDim,
+                                      int srcAddDim,
+                                      IndexType innerSize,
+                                      long dstAddDimSize) {
+  // We stride over the output including the indexed dimension
+  // (totalSize), and calculate the destination index point based on that
+  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+    linearIndex < innerSize * indices.sizes[0];
+       linearIndex += gridDim.x * blockDim.x) {
+    IndexType srcIndex = linearIndex / innerSize;
+    IndexType elementInSlice = linearIndex % innerSize;
+
+    // Lua indices begin at 1
+    IndexType dstIndex =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(srcIndex, indices)] - 1;
+
+    if (dstIndex < dstAddDimSize) {
+      IndexType dstOffset =
+        IndexToOffset<IndexType, DstDim>::get(elementInSlice, dst);
+      dstOffset += dstIndex * dst.strides[dstAddDim];
+
+      IndexType srcOffset =
+        IndexToOffset<IndexType, SrcDim>::get(elementInSlice, src);
+      srcOffset += srcIndex * src.strides[srcAddDim];
+
+      atomicAdd(&dst.data[dstOffset], src.data[srcOffset]);
+    }
+  }
+}
+
+void THCudaTensor_indexAdd_long(THCState *state, THCudaTensor *dst, int dim, THLongTensor *indices, THCudaTensor *src)
 {
-  THAssert(THCudaTensor_checkGPU(state, 1, res_));
+  THAssert(THCudaTensor_checkGPU(state, 2, dst, src));
 
   THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
   THCudaTensor_copyLong(state, indices_, indices);
 
-  THCudaTensor_indexCopy(state, res_, dim, indices_, src);
+  THCudaTensor_indexAdd(state, dst, dim, indices_, src);
 
   THCudaTensor_free(state, indices_);
 }
 
-void THCudaTensor_indexCopy(THCState *state, THCudaTensor *res_, int dim, THCudaTensor *indices, THCudaTensor *src)
+void THCudaTensor_indexAdd(THCState *state, THCudaTensor *dst, int dim, THCudaTensor *indices, THCudaTensor *src)
 {
-  THAssert(THCudaTensor_checkGPU(state, 2, res_, src));
-  long *stride_;
-  long nIndex = indices->size[0];
-  long nRes;
+  THAssert(THCudaTensor_checkGPU(state, 3, dst, indices, src));
 
-  THArgCheck(indices->nDimension == 1, 3, "expecting vector of indices");
-  THArgCheck(dim < src->nDimension, 4, "Indexing dim is out of bounds");
-  THArgCheck(src->nDimension > 0, 2, "Source tensor is empty");
-  THArgCheck(nIndex == src->size[dim], 4, "length of src.size[dim] is not equal to length of indices");
+  THCCheckTensorDims(state, dst, 2);
+  THCCheckTensorDims(state, src, 5);
+  THCCheckTensorDims(state, indices, 4);
 
-  src = THCudaTensor_newContiguous(state, src);
-  indices = THCudaTensor_newContiguous(state, indices);
+  long numIndices = THCudaTensor_nElement(state, indices);
 
-  nRes = THCudaTensor_nElement(state, res_);
-  dim3 nthreads(16, 16);
-  dim3 nblocks(ceil((float)nRes / nIndex / (16*16)));
+  long srcDims = THCudaTensor_nDimension(state, src);
+  cudaStream_t stream = THCState_getCurrentStream(state);
 
-  THCudaCheck(THCudaMalloc(state, (void**)&stride_, res_->nDimension * sizeof(long)));
-  THCudaCheck(cudaMemcpy(stride_, res_->stride, res_->nDimension * sizeof(long), cudaMemcpyHostToDevice));
+  THArgCheck(THCudaTensor_nDimension(state, indices) == 1, 3,
+             "expecting vector of indices");
+  THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
+  THArgCheck(srcDims > 0, 2, "Source tensor is empty");
+  THArgCheck(numIndices == src->size[dim], 4, "length of src.size[dim] is not equal to length of indices");
 
-  THCudaTensor_kernel_indexCopy<<<nblocks, nthreads, 0, THCState_getCurrentStream(state)>>>(
-    THCudaTensor_data(state, res_), THCudaTensor_data(state, src),
-    stride_, THCudaTensor_data(state, indices),
-    res_->nDimension, dim, nIndex,
-    THCudaTensor_nElement(state, src), res_->size[dim]
-  );
+  int indContig = THCudaTensor_isContiguous(state, indices);
 
-  THCudaCheck(THCudaFree(state, stride_));
-  THCudaTensor_free(state, indices);
-  THCudaTensor_free(state, src);
+  // The `src` is partitioned into two parts:
+  // -the size of each slice we are indexing, which is the
+  // total size of the tensor ignoring dimension `dim`;
+  // -the number of indices we are choosing, which is the total size
+  // of the tensor `indices`.
+  long srcTotalSize = THCudaTensor_nElement(state, src);
+  long dstAddDimSize = THCudaTensor_size(state, dst, dim);
+  long sliceSize = srcTotalSize / numIndices;
+
+  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+
+#define SMALL_INDEX(TYPE, DST_DIM, SRC_DIM, IDX_DIM)            \
+  indexAddSmallIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>           \
+    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(           \
+      dstInfo, srcInfo, indicesInfo,                            \
+      dstAddDim, srcAddDim, sliceSize, dstAddDimSize);
+
+#define LARGE_INDEX(TYPE, DST_DIM, SRC_DIM, IDX_DIM)            \
+  indexAddLargeIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>           \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(           \
+      dstInfo, srcInfo, indicesInfo,                            \
+      dstAddDim, srcAddDim, sliceSize, dstAddDimSize);
+
+  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, 128L), (long)(mpc * 8)));
+  dim3 smallIndexBlock(std::min(sliceSize, 128L));
+
+  dim3 largeIndexGrid(std::min(THCCeilDiv(srcTotalSize, 128L), (long)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(srcTotalSize, 128L));
+
+  if (THC_canUse32BitIndexMath(state, dst) &&
+      THC_canUse32BitIndexMath(state, src) &&
+      THC_canUse32BitIndexMath(state, indices)) {
+    TensorInfo<unsigned int> dstInfo(state, dst);
+    int dstAddDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstAddDim] = 1;
+
+    TensorInfo<unsigned int> srcInfo(state, src);
+    int srcAddDim = srcInfo.collapseDims(dim);
+    srcInfo.sizes[srcAddDim] = 1;
+
+    TensorInfo<unsigned int> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
+
+    // A reasonable choice for when to have each thread iterate over
+    // indices to choose
+    if (numIndices <= 16) {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        SMALL_INDEX(unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        SMALL_INDEX(unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        SMALL_INDEX(unsigned int, 3, 3, -2);
+      } else {
+        SMALL_INDEX(unsigned int, -1, -1, -1);
+      }
+    } else {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        LARGE_INDEX(unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        LARGE_INDEX(unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        LARGE_INDEX(unsigned int, 3, 3, -2);
+      } else {
+        LARGE_INDEX(unsigned int, -1, -1, -1);
+      }
+    }
+  } else {
+    TensorInfo<unsigned long> dstInfo(state, dst);
+    int dstAddDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstAddDim] = 1;
+
+    TensorInfo<unsigned long> srcInfo(state, src);
+    int srcAddDim = srcInfo.collapseDims(dim);
+    srcInfo.sizes[srcAddDim] = 1;
+
+    TensorInfo<unsigned long> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
+
+    LARGE_INDEX(unsigned long, -1, -1, -1);
+  }
+
+#undef SMALL_INDEX
+#undef LARGE_INDEX
 }
 
-void THCudaTensor_indexAdd_long(THCState *state, THCudaTensor *res_, int dim, THLongTensor *indices, THCudaTensor *src)
+// We prefer this kernel to avoid reloading index points if the number
+// of indices is a small number.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is large, then the
+// indexFillLargeIndex kernel is a better choice to increase
+// parallelism.
+template <typename IndexType, int DstDim, int IdxDim>
+__global__ void indexFillSmallIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> indices,
+                                      int dstFillDim,
+                                      IndexType innerSize,
+                                      long dstFillDimSize,
+                                      float val) {
+  // In order to avoid reloading the index that we are copying, load
+  // it once to handle all of the points that are being selected, so
+  // it can be reused as much as possible. This kernel is chosen when
+  // this is a good choice (small number of chosen indices), since
+  // re-accessing indices in addition to src elements can be slow.
+  for (IndexType dstIndex = 0; dstIndex < indices.sizes[0]; ++dstIndex) {
+    // Lua indices begin at 1
+    IndexType dstIndex_ =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(dstIndex, indices)] - 1;
+
+    if (dstIndex < dstFillDimSize) {
+      // We stride over the output ignoring the indexed dimension
+      // (innerSize), whose offset calculation is handled differently
+      for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+           linearIndex < innerSize;
+           linearIndex += gridDim.x * blockDim.x) {
+        IndexType dstOffset =
+          IndexToOffset<IndexType, DstDim>::get(linearIndex, dst);
+        dstOffset += dstIndex_ * dst.strides[dstFillDim];
+
+        dst.data[dstOffset] = val;
+      }
+    }
+  }
+}
+
+// We prefer this kernel to balance parallelism across index points,
+// if there are a large number of indices.
+// This kernel in fact works for all choices of problem size, but if
+// the number of indices chosen is small, then the
+// indexFillSmallIndex kernel is a better choice to reduce memory
+// accesses.
+template <typename IndexType, int DstDim, int IdxDim>
+__global__ void indexFillLargeIndex(TensorInfo<IndexType> dst,
+                                      TensorInfo<IndexType> indices,
+                                      int dstFillDim,
+                                      IndexType innerSize,
+                                      long dstFillDimSize,
+                                      float val) {
+  // We stride over the output including the indexed dimension
+  // (totalSize), and calculate the destination index point based on that
+  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+    linearIndex < innerSize * indices.sizes[0];
+       linearIndex += gridDim.x * blockDim.x) {
+    IndexType dstIndex = linearIndex / innerSize;
+    IndexType elementInSlice = linearIndex % innerSize;
+
+    // Lua indices begin at 1
+    IndexType dstIndex_ =
+      indices.data[IndexToOffset<IndexType, IdxDim>::get(dstIndex, indices)] - 1;
+
+    if (dstIndex_ < dstFillDimSize) {
+      IndexType dstOffset =
+        IndexToOffset<IndexType, DstDim>::get(elementInSlice, dst);
+      dstOffset += dstIndex_ * dst.strides[dstFillDim];
+
+      dst.data[dstOffset] = 1;
+    }
+  }
+}
+
+void THCudaTensor_indexFill_long(THCState *state, THCudaTensor *dst, int dim, THLongTensor *indices, float val)
 {
-  THAssert(THCudaTensor_checkGPU(state, 1, res_));
+  THAssert(THCudaTensor_checkGPU(state, 1, dst));
 
   THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
   THCudaTensor_copyLong(state, indices_, indices);
 
-  THCudaTensor_indexAdd(state, res_, dim, indices_, src);
+  THCudaTensor_indexFill(state, dst, dim, indices_, val);
 
   THCudaTensor_free(state, indices_);
 }
 
-void THCudaTensor_indexAdd(THCState *state, THCudaTensor *res_, int dim, THCudaTensor *indices, THCudaTensor *src)
+void THCudaTensor_indexFill(THCState *state, THCudaTensor *dst, int dim, THCudaTensor *indices, float val)
 {
-  THAssert(THCudaTensor_checkGPU(state, 2, res_, src));
-  long *stride_;
-  long nIndex = indices->size[0];
-  long nRes;
+  THAssert(THCudaTensor_checkGPU(state, 2, dst, indices));
+  THCCheckTensorDims(state, dst, 2);
+  THCCheckTensorDims(state, indices, 4);
 
-  THArgCheck(indices->nDimension == 1, 3, "expecting vector of indices");
-  THArgCheck(dim < src->nDimension, 4, "Indexing dim is out of bounds");
-  THArgCheck(src->nDimension > 0, 2, "Source tensor is empty");
-  THArgCheck(nIndex == src->size[dim], 4, "length of src.size[dim] is not equal to length of indices");
+  long numIndices = THCudaTensor_nElement(state, indices);
 
-  src = THCudaTensor_newContiguous(state, src);
-  indices = THCudaTensor_newContiguous(state, indices);
+  long srcDims = THCudaTensor_nDimension(state, dst);
+  cudaStream_t stream = THCState_getCurrentStream(state);
 
-  nRes = THCudaTensor_nElement(state, res_);
-  dim3 nthreads(16, 16);
-  dim3 nblocks(ceil((float)nRes / nIndex / (16*16)));
+  THArgCheck(THCudaTensor_nDimension(state, indices) == 1, 3,
+             "expecting vector of indices");
+  THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
+  THArgCheck(srcDims > 0, 2, "Source tensor is empty");
 
-  THCudaCheck(THCudaMalloc(state, (void**)&stride_, res_->nDimension * sizeof(long)));
-  THCudaCheck(cudaMemcpy(stride_, res_->stride, res_->nDimension * sizeof(long), cudaMemcpyHostToDevice));
+  int indContig = THCudaTensor_isContiguous(state, indices);
 
-  THCudaTensor_kernel_indexAdd<<<nblocks, nthreads, 0, THCState_getCurrentStream(state)>>>(
-    THCudaTensor_data(state, res_), THCudaTensor_data(state, src),
-    stride_, THCudaTensor_data(state, indices),
-    res_->nDimension, dim, nIndex,
-    THCudaTensor_nElement(state, src), res_->size[dim]
-  );
+  // The `src` is partitioned into two parts:
+  // -the size of each slice we are indexing, which is the
+  // total size of the tensor ignoring dimension `dim`;
+  // -the number of indices we are choosing, which is the total size
+  // of the tensor `indices`.
+  long dstTotalSize = THCudaTensor_nElement(state, dst);
+  long dstFillDimSize = THCudaTensor_size(state, dst, dim);
+  long sliceSize = dstTotalSize / dstFillDimSize;
 
-  THCudaCheck(THCudaFree(state, stride_));
-  THCudaTensor_free(state, indices);
-  THCudaTensor_free(state, src);
-}
+  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
 
-void THCudaTensor_indexFill_long(THCState *state, THCudaTensor *res_, int dim, THLongTensor *indices, float val)
-{
-  THAssert(THCudaTensor_checkGPU(state, 1, res_));
+#define SMALL_INDEX(TYPE, DST_DIM, IDX_DIM)            \
+  indexFillSmallIndex<TYPE, DST_DIM, IDX_DIM>          \
+    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(  \
+      dstInfo, indicesInfo,                            \
+      dstFillDim, sliceSize, dstFillDimSize, val);
 
-  THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
-  THCudaTensor_copyLong(state, indices_, indices);
+#define LARGE_INDEX(TYPE, DST_DIM, IDX_DIM)            \
+  indexFillLargeIndex<TYPE, DST_DIM, IDX_DIM>          \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(  \
+      dstInfo, indicesInfo,                            \
+      dstFillDim, sliceSize, dstFillDimSize, val);
 
-  THCudaTensor_indexFill(state, res_, dim, indices_, val);
+  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, 128L), (long)(mpc * 8)));
+  dim3 smallIndexBlock(std::min(sliceSize, 128L));
 
-  THCudaTensor_free(state, indices_);
-}
+  dim3 largeIndexGrid(std::min(THCCeilDiv(dstTotalSize, 128L), (long)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(dstTotalSize, 128L));
 
-void THCudaTensor_indexFill(THCState *state, THCudaTensor *res_, int dim, THCudaTensor *indices, float val)
-{
-  THAssert(THCudaTensor_checkGPU(state, 1, res_));
-  long *stride_;
-  long nIndex = indices->size[0];
-  long nRes;
+  if (THC_canUse32BitIndexMath(state, dst) &&
+      THC_canUse32BitIndexMath(state, indices)) {
+    TensorInfo<unsigned int> dstInfo(state, dst);
+    int dstFillDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstFillDim] = 1;
 
-  THArgCheck(indices->nDimension == 1, 3, "Index is supposed to be a vector");
-  THArgCheck(dim < res_->nDimension,4,"Indexing dim is out of bounds");
-  THArgCheck(res_->nDimension > 0, 2, "Source tensor is empty");
+    TensorInfo<unsigned int> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
 
-  nRes = THCudaTensor_nElement(state, res_) / res_->size[dim] * nIndex;
-  indices = THCudaTensor_newContiguous(state, indices);
+    // A reasonable choice for when to have each thread iterate over
+    // indices to choose
+    if (numIndices <= 16) {
+      if (dstInfo.dims == 1 && indContig) {
+        SMALL_INDEX(unsigned int, 1, -2);
+      } else if (dstInfo.dims == 2 && indContig) {
+        SMALL_INDEX(unsigned int, 2, -2);
+      } else if (dstInfo.dims == 3 && indContig) {
+        SMALL_INDEX(unsigned int, 3, -2);
+      } else {
+        SMALL_INDEX(unsigned int, -1, -1);
+      }
+    } else {
+      if (dstInfo.dims == 1 && indContig) {
+        LARGE_INDEX(unsigned int, 1, -2);
+      } else if (dstInfo.dims == 2 && indContig) {
+        LARGE_INDEX(unsigned int, 2, -2);
+      } else if (dstInfo.dims == 3 && indContig) {
+        LARGE_INDEX(unsigned int, 3, -2);
+      } else {
+        LARGE_INDEX(unsigned int, -1, -1);
+      }
+    }
+  } else {
+    TensorInfo<unsigned long> dstInfo(state, dst);
+    int dstFillDim = dstInfo.collapseDims(dim);
+    dstInfo.sizes[dstFillDim] = 1;
 
-  dim3 nthreads(16, 16);
-  dim3 nblocks(ceil((float)nRes / nIndex / (16*16)));
+    TensorInfo<unsigned long> indicesInfo(state, indices);
+    indicesInfo.collapseDims();
 
-  THCudaCheck(THCudaMalloc(state, (void**)&stride_, res_->nDimension * sizeof(long)));
-  THCudaCheck(cudaMemcpy(stride_, res_->stride, res_->nDimension * sizeof(long), cudaMemcpyHostToDevice));
+    LARGE_INDEX(unsigned long, -1, -1);
+  }
 
-  THCudaTensor_kernel_indexFill<<<nblocks, nthreads, 0, THCState_getCurrentStream(state)>>>(
-    THCudaTensor_data(state, res_), stride_, THCudaTensor_data(state, indices),
-    res_->nDimension, dim, nIndex, nRes, res_->size[dim], val
-  );
-
-  THCudaCheck(THCudaFree(state, stride_));
-  THCudaTensor_free(state, indices);
+#undef SMALL_INDEX
+#undef LARGE_INDEX
 }
 
 // We prefer this kernel to avoid reloading index points if the number
@@ -269,8 +605,8 @@ __global__ void indexSelectSmallIndex(TensorInfo<IndexType> dst,
                                       TensorInfo<IndexType> indices,
                                       int dstSelectDim,
                                       int srcSelectDim,
-                                      IndexType totalSize,
-                                      IndexType innerSize) {
+                                      IndexType innerSize,
+                                      long srcSelectDimSize) {
   // In order to avoid reloading the index that we are copying, load
   // it once to handle all of the points that are being selected, so
   // it can be reused as much as possible. This kernel is chosen when
@@ -281,20 +617,22 @@ __global__ void indexSelectSmallIndex(TensorInfo<IndexType> dst,
     IndexType srcIndex =
       indices.data[IndexToOffset<IndexType, IdxDim>::get(dstIndex, indices)] - 1;
 
-    // We stride over the output ignoring the indexed dimension
-    // (innerSize), whose offset calculation is handled differently
-    for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
-         linearIndex < innerSize;
-         linearIndex += gridDim.x * blockDim.x) {
-      IndexType dstOffset =
-        IndexToOffset<IndexType, DstDim>::get(linearIndex, dst);
-      dstOffset += dstIndex * dst.strides[dstSelectDim];
+    if (srcIndex < srcSelectDimSize) {
+      // We stride over the output ignoring the indexed dimension
+      // (innerSize), whose offset calculation is handled differently
+      for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+           linearIndex < innerSize;
+           linearIndex += gridDim.x * blockDim.x) {
+        IndexType dstOffset =
+          IndexToOffset<IndexType, DstDim>::get(linearIndex, dst);
+        dstOffset += dstIndex * dst.strides[dstSelectDim];
 
-      IndexType srcOffset =
-        IndexToOffset<IndexType, SrcDim>::get(linearIndex, src);
-      srcOffset += srcIndex * src.strides[srcSelectDim];
+        IndexType srcOffset =
+          IndexToOffset<IndexType, SrcDim>::get(linearIndex, src);
+        srcOffset += srcIndex * src.strides[srcSelectDim];
 
-      dst.data[dstOffset] = src.data[srcOffset];
+        dst.data[dstOffset] = src.data[srcOffset];
+      }
     }
   }
 }
@@ -312,7 +650,8 @@ __global__ void indexSelectLargeIndex(TensorInfo<IndexType> dst,
                                       int dstSelectDim,
                                       int srcSelectDim,
                                       IndexType totalSize,
-                                      IndexType innerSize) {
+                                      IndexType innerSize,
+                                      long srcSelectDimSize) {
   // We stride over the output including the indexed dimension
   // (totalSize), and calculate the destination index point based on that
   for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
@@ -325,33 +664,35 @@ __global__ void indexSelectLargeIndex(TensorInfo<IndexType> dst,
     IndexType srcIndex =
       indices.data[IndexToOffset<IndexType, IdxDim>::get(dstIndex, indices)] - 1;
 
-    IndexType dstOffset =
-      IndexToOffset<IndexType, DstDim>::get(elementInSlice, dst);
-    dstOffset += dstIndex * dst.strides[dstSelectDim];
+    if (srcIndex < srcSelectDimSize) {
+      IndexType dstOffset =
+        IndexToOffset<IndexType, DstDim>::get(elementInSlice, dst);
+      dstOffset += dstIndex * dst.strides[dstSelectDim];
 
-    IndexType srcOffset =
-      IndexToOffset<IndexType, SrcDim>::get(elementInSlice, src);
-    srcOffset += srcIndex * src.strides[srcSelectDim];
+      IndexType srcOffset =
+        IndexToOffset<IndexType, SrcDim>::get(elementInSlice, src);
+      srcOffset += srcIndex * src.strides[srcSelectDim];
 
-    dst.data[dstOffset] = src.data[srcOffset];
+      dst.data[dstOffset] = src.data[srcOffset];
+    }
   }
 }
 
-void THCudaTensor_indexSelect_long(THCState *state, THCudaTensor *res_, THCudaTensor *src, int dim, THLongTensor *indices)
+void THCudaTensor_indexSelect_long(THCState *state, THCudaTensor *dst, THCudaTensor *src, int dim, THLongTensor *indices)
 {
-  THAssert(THCudaTensor_checkGPU(state, 2, res_, src));
+  THAssert(THCudaTensor_checkGPU(state, 2, dst, src));
 
   THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
   THCudaTensor_copyLong(state, indices_, indices);
 
-  THCudaTensor_indexSelect(state, res_, src, dim, indices_);
+  THCudaTensor_indexSelect(state, dst, src, dim, indices_);
 
   THCudaTensor_free(state, indices_);
 }
 
 void THCudaTensor_indexSelect(THCState *state, THCudaTensor *dst, THCudaTensor *src, int dim, THCudaTensor *indices)
 {
-  THAssert(THCudaTensor_checkGPU(state, 2, dst, src));
+  THAssert(THCudaTensor_checkGPU(state, 3, dst, src, indices));
 
   THCCheckTensorDims(state, dst, 2);
   THCCheckTensorDims(state, src, 3);
@@ -379,8 +720,9 @@ void THCudaTensor_indexSelect(THCState *state, THCudaTensor *dst, THCudaTensor *
   // total size of the tensor ignoring dimension `dim`;
   // -the number of indices we are choosing, which is the total size
   // of the tensor `indices`.
-  long totalSize = THCudaTensor_nElement(state, dst);
-  long sliceSize = totalSize / numIndices;
+  long dstTotalSize = THCudaTensor_nElement(state, dst);
+  long srcSelectDimSize = THCudaTensor_size(state, src, dim);
+  long sliceSize = dstTotalSize / numIndices;
 
   int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
 
@@ -388,19 +730,19 @@ void THCudaTensor_indexSelect(THCState *state, THCudaTensor *dst, THCudaTensor *
   indexSelectSmallIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>        \
     <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(           \
       dstInfo, srcInfo, indicesInfo,                            \
-      dstSelectDim, srcSelectDim, totalSize, sliceSize);
+      dstSelectDim, srcSelectDim, sliceSize, srcSelectDimSize);
 
 #define LARGE_INDEX(TYPE, DST_DIM, SRC_DIM, IDX_DIM)            \
   indexSelectLargeIndex<TYPE, DST_DIM, SRC_DIM, IDX_DIM>        \
     <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(           \
       dstInfo, srcInfo, indicesInfo,                            \
-      dstSelectDim, srcSelectDim, totalSize, sliceSize);
+      dstSelectDim, srcSelectDim, dstTotalSize, sliceSize, srcSelectDimSize);
 
   dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, 128L), (long)(mpc * 8)));
   dim3 smallIndexBlock(std::min(sliceSize, 128L));
 
-  dim3 largeIndexGrid(std::min(THCCeilDiv(totalSize, 128L), (long)(mpc * 8)));
-  dim3 largeIndexBlock(std::min(totalSize, 128L));
+  dim3 largeIndexGrid(std::min(THCCeilDiv(dstTotalSize, 128L), (long)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(dstTotalSize, 128L));
 
   if (THC_canUse32BitIndexMath(state, dst) &&
       THC_canUse32BitIndexMath(state, src) &&

--- a/test/test.lua
+++ b/test/test.lua
@@ -1230,6 +1230,39 @@ function test.renorm()
    checkMultiDevice(x, 'renorm', 4, 2, maxnorm)
 end
 
+function test.indexCopy()
+   for tries = 1, 5 do
+      local t = createTestTensor(1000000)
+      local selectdim = chooseInt(1, t:nDimension())
+      local indices = torch.randperm(t:size(selectdim)):long()
+
+      compareFloatAndCudaTensorArgs(
+          t, 'indexCopy', selectdim, indices, t:clone())
+   end
+end
+
+function test.indexAdd()
+   for tries = 1, 5 do
+      local t = createTestTensor(1000000)
+      local selectdim = chooseInt(1, t:nDimension())
+      local indices = torch.randperm(t:size(selectdim)):long()
+
+      compareFloatAndCudaTensorArgs(
+          t, 'indexAdd', selectdim, indices, t:clone())
+   end
+end
+
+function test.indexFill()
+   for tries = 1, 5 do
+      local t = createTestTensor(1000000)
+      local selectdim = chooseInt(1, t:nDimension())
+      local numIndices = chooseInt(1, t:size(selectdim))
+      local indices = torch.randperm(numIndices):long()
+
+      compareFloatAndCuda(t, 'indexFill', selectdim, indices, 1)
+   end
+end
+
 function test.indexSelect()
    for tries = 1, 5 do
       local t = createTestTensor(1000000)
@@ -2092,7 +2125,7 @@ function test.cudaTypeCopy()
          -- this is equivalent to t = torch.XTensor():copy(t)
          t = torch[tensorSubtype](3,4):copy(t)
       end
-      
+
       -- check the type
       tester:assert(t:type() == tensorType, t:type() .. ' ~= ' .. tensorType)
 
@@ -2104,7 +2137,7 @@ function test.cudaTypeCopy()
       -- check data
       tester:assertTensorEq(t:double(), t0, 0)
 
-      
+
       -- check indexing
       -- FIXME: doesn't work yet
       -- tester:assert(ct[{1,1}] == 1)
@@ -2148,7 +2181,7 @@ function test.cudaStorageTypeCopy()
 
       -- this is equivalent to t = torch.XStorage():copy(t)
       t = torch[storageSubtype](12):copy(t)
-      
+
       -- check the type
       tester:assert(torch.type(t) == storageType, torch.type(t) .. ' ~= ' .. storageType)
 


### PR DESCRIPTION
Fix indexing bug in indexCopy, indexAdd, indexFill in Cutorch + tests. The indexing logic was broken (and only touched indices <= 256).