### PR TITLE
properly shutdown and free cutorch on exit

### DIFF
--- a/test/test_shutdown.lua
+++ b/test/test_shutdown.lua
@@ -1,0 +1,11 @@
+local Threads = require 'threads'
+require 'cutorch'
+
+print('Memory usage before intialization of threads [free memory], [total memory]')
+print(cutorch.getMemoryUsage())
+threads = Threads(100, function() require 'cutorch' end)
+print('Memory usage after intialization of threads [free memory], [total memory]')
+print(cutorch.getMemoryUsage())
+threads:terminate()
+print('Memory usage after termination of threads [free memory], [total memory]')
+print(cutorch.getMemoryUsage())


### PR DESCRIPTION
This makes sure no leaking memory on shutting down the lua state, when using threads, or embedding cutorch in an external C++ process.

Fixes https://github.com/torch/cutorch/issues/280

Without patch:
Memory usage before intialization of threads [free memory], [total memory]
11942445056     12079136768
Memory usage after intialization of threads [free memory], [total memory]
11900502016     12079136768
Memory usage after termination of threads [free memory], [total memory]
11942445056     12079136768

With patch:
Memory usage before intialization of threads [free memory], [total memory]
11924619264     12079136768
Memory usage after intialization of threads [free memory], [total memory]
11829182464     12079136768
Memory usage after termination of threads [free memory], [total memory]
11829182464     12079136768