### PR TITLE
Add FP16 support (CudaHalfStorage, CudaHalfTensor)

### DIFF
--- a/FFI.lua
+++ b/FFI.lua
@@ -44,6 +44,9 @@ cudaStream_t THCState_getCurrentStream(THCState *state);
       {'long','Long'},
       {'double','Double'},
   }
+  if cutorch.hasHalf then
+      table.insert(CudaTypes, {'half','Half'})
+  end
 
    for _, typedata in ipairs(CudaTypes) do
       local real, Real = unpack(typedata)
@@ -76,6 +79,14 @@ typedef struct THCTensor
 
       ctype_def = ctype_def:gsub('real',real):gsub('THCStorage','THCuda'..Real..'Storage'):gsub('THCTensor','THCuda'..Real..'Tensor')
       cdefs = cdefs .. ctype_def
+   end
+   if cutorch.hasHalf then
+      ffi.cdef([[
+typedef struct {
+    unsigned short x;
+} __half;
+typedef __half half;
+      ]])
    end
    ffi.cdef(cdefs)
 

--- a/Tensor.lua
+++ b/Tensor.lua
@@ -39,6 +39,9 @@ local TensorTypes = {
    cudaLong   = 'torch.CudaLongTensor'
 }
 
+if cutorch.hasHalf then
+    TensorTypes['cudaHalf'] = 'torch.CudaHalfTensor'
+end
 
 local function Tensor__converter(type)
     return function(self)
@@ -81,4 +84,14 @@ for ValueType, CudaTensorType in pairs(CudaTensorTypes) do
     return host_tensor:totable()
   end
   rawset(torch.getmetatable(CudaTensorType), 'totable', Tensor__totable)
+end
+
+if cutorch.hasHalf then
+   do
+      local function Tensor__totable(self)
+         local host_tensor = self:float()
+         return self:float():totable()
+      end
+      rawset(torch.getmetatable('torch.CudaHalfTensor'), 'totable', Tensor__totable)
+   end
 end

--- a/init.c
+++ b/init.c
@@ -10,6 +10,9 @@ extern void cutorch_CudaIntStorage_init(lua_State* L);
 extern void cutorch_CudaLongStorage_init(lua_State* L);
 extern void cutorch_CudaStorage_init(lua_State* L);
 extern void cutorch_CudaDoubleStorage_init(lua_State* L);
+#if CUDA_VERSION >= 7050
+extern void cutorch_CudaHalfStorage_init(lua_State* L);
+#endif
 
 extern void cutorch_CudaByteTensor_init(lua_State* L);
 extern void cutorch_CudaCharTensor_init(lua_State* L);
@@ -18,6 +21,9 @@ extern void cutorch_CudaIntTensor_init(lua_State* L);
 extern void cutorch_CudaLongTensor_init(lua_State* L);
 extern void cutorch_CudaTensor_init(lua_State* L);
 extern void cutorch_CudaDoubleTensor_init(lua_State* L);
+#if CUDA_VERSION >= 7050
+extern void cutorch_CudaHalfTensor_init(lua_State* L);
+#endif
 
 extern void cutorch_CudaTensorMath_init(lua_State* L);
 extern void cutorch_CudaTensorOperator_init(lua_State* L);
@@ -925,6 +931,9 @@ int luaopen_libcutorch(lua_State *L)
   cutorch_CudaLongStorage_init(L);
   cutorch_CudaStorage_init(L);
   cutorch_CudaDoubleStorage_init(L);
+#if CUDA_VERSION >= 7050
+  cutorch_CudaHalfStorage_init(L);
+#endif
 
   cutorch_CudaByteTensor_init(L);
   cutorch_CudaCharTensor_init(L);
@@ -933,6 +942,9 @@ int luaopen_libcutorch(lua_State *L)
   cutorch_CudaLongTensor_init(L);
   cutorch_CudaTensor_init(L);
   cutorch_CudaDoubleTensor_init(L);
+#if CUDA_VERSION >= 7050
+  cutorch_CudaHalfTensor_init(L);
+#endif
 
   cutorch_CudaTensorMath_init(L);
   cutorch_CudaTensorOperator_init(L);
@@ -941,6 +953,13 @@ int luaopen_libcutorch(lua_State *L)
   /* Store state in cutorch table. */
   lua_pushlightuserdata(L, state);
   lua_setfield(L, -2, "_state");
+
+#if CUDA_VERSION >= 7050
+  lua_pushboolean(L, 1);
+#else
+  lua_pushboolean(L, 0);
+#endif
+  lua_setfield(L, -2, "hasHalf");
 
   /* when cutorch goes out of scope, we need to make sure THCState is properly
      shut down (so that memory doesn not leak. Since _state is a lightuserdata

--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,10 @@ torch.CudaStorage.__tostring__       = torch.FloatStorage.__tostring__
 torch.CudaTensor.__tostring__        = torch.FloatTensor.__tostring__
 torch.CudaDoubleStorage.__tostring__ = torch.DoubleStorage.__tostring__
 torch.CudaDoubleTensor.__tostring__  = torch.DoubleTensor.__tostring__
+if cutorch.hasHalf then
+   torch.CudaHalfStorage.__tostring__  = torch.FloatStorage.__tostring__
+   torch.CudaHalfTensor.__tostring__  = torch.FloatTensor.__tostring__
+end
 
 require('cutorch.Tensor')
 require('cutorch.FFI')

--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -114,6 +114,10 @@ SET(src-cuda
   THCTensorTopK.cu
   )
 
+IF(NOT ${CUDA_VERSION} LESS 7.5)
+  LIST(APPEND src-cuda THCHalf.cu)
+ENDIF()
+
 CUDA_ADD_LIBRARY(THC SHARED ${src} ${src-cuda})
 CUDA_ADD_CUBLAS_TO_TARGET(THC)
 TARGET_LINK_LIBRARIES(THC TH ${CUDA_curand_LIBRARY})
@@ -154,6 +158,7 @@ INSTALL(FILES
           THCDeviceTensorUtils.cuh
           THCDeviceTensorUtils-inl.cuh
           THCGenerateAllTypes.h
+          THCHalf.h
           DESTINATION "${THC_INSTALL_INCLUDE_SUBDIR}/THC")
 
 INSTALL(FILES

--- a/lib/THC/THCGenerateAllTypes.h
+++ b/lib/THC/THCGenerateAllTypes.h
@@ -9,7 +9,12 @@
 #define THCTypeIdxLong   5
 #define THCTypeIdxFloat  6
 #define THCTypeIdxDouble 7
+#define THCTypeIdxHalf   8
 #define THCTypeIdx_(T) TH_CONCAT_2(THCTypeIdx,T)
+
+#define hostreal real
+#define hostrealToReal(x) (x)
+#define realToHostreal(x) (x)
 
 #define real unsigned char
 #define accreal long
@@ -103,6 +108,34 @@
 #undef CReal
 #undef THC_REAL_IS_DOUBLE
 
+#if CUDA_VERSION >= 7050
+
+#undef hostreal
+#undef hostrealToReal
+#undef realToHostreal
+#define hostreal float
+#define hostrealToReal(x) THC_float2half(x);
+#define realToHostreal(x) THC_half2float(x);
+
+#define real half
+#define accreal half
+#define Real Half
+#define CReal CudaHalf
+#define THC_REAL_IS_HALF
+#line 1 THC_GENERIC_FILE
+#include THC_GENERIC_FILE
+#undef real
+#undef accreal
+#undef Real
+#undef CReal
+#undef THC_REAL_IS_HALF
+
+#endif // CUDA_VERSION >= 7050
+
+#undef hostreal
+#undef hostrealToReal
+#undef realToHostreal
+
 #undef THCTypeIdxByte
 #undef THCTypeIdxChar
 #undef THCTypeIdxShort
@@ -110,5 +143,6 @@
 #undef THCTypeIdxLong
 #undef THCTypeIdxFloat
 #undef THCTypeIdxDouble
+#undef THCTypeIdxHalf
 
 #undef THC_GENERIC_FILE

--- a/lib/THC/THCHalf.cu
+++ b/lib/THC/THCHalf.cu
@@ -1,0 +1,104 @@
+#include "THCHalf.h"
+#include <thrust/transform.h>
+#include <thrust/execution_policy.h>
+
+struct __half2floatOp {
+  __device__ float operator()(half v) { return __half2float(v); }
+};
+
+struct __float2halfOp {
+  __device__ half operator()(float v) { return __float2half(v); }
+};
+
+void THCFloat2Half(THCState *state, half *out, float *in, long len) {
+  thrust::transform(
+#if CUDA_VERSION >= 7000
+    thrust::cuda::par.on(THCState_getCurrentStream(state)),
+#else
+    thrust::device,
+#endif
+    in, in + len, out, __float2halfOp());
+}
+
+void THCHalf2Float(THCState *state, float *out, half *in, long len) {
+  thrust::transform(
+#if CUDA_VERSION >= 7000
+    thrust::cuda::par.on(THCState_getCurrentStream(state)),
+#else
+    thrust::device,
+#endif
+    in, in + len, out, __half2floatOp());
+}
+
+float THC_half2float(half a)
+{
+  THError("half2float not implemented yet");
+  return 0;
+}
+
+/*
+  Copyright (c) 2015, Norbert Juffa
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+half THC_float2half(float a)
+{
+  uint32_t ia;
+  uint16_t ir;
+  memcpy(&ia, &a, sizeof(float));
+
+  ir = (ia >> 16) & 0x8000;
+  if ((ia & 0x7f800000) == 0x7f800000) {
+    if ((ia & 0x7fffffff) == 0x7f800000) {
+      ir |= 0x7c00; /* infinity */
+    } else {
+      ir = 0x7fff; /* canonical NaN */
+    }
+  } else if ((ia & 0x7f800000) >= 0x33000000) {
+    int shift = (int)((ia >> 23) & 0xff) - 127;
+    if (shift > 15) {
+      ir |= 0x7c00; /* infinity */
+    } else {
+      ia = (ia & 0x007fffff) | 0x00800000; /* extract mantissa */
+      if (shift < -14) { /* denormal */
+        ir |= ia >> (-1 - shift);
+        ia = ia << (32 - (-1 - shift));
+      } else { /* normal */
+        ir |= ia >> (24 - 11);
+        ia = ia << (32 - (24 - 11));
+        ir = ir + ((14 + shift) << 10);
+      }
+      /* IEEE-754 round to nearest of even */
+      if ((ia > 0x80000000) || ((ia == 0x80000000) && (ir & 1))) {
+        ir++;
+      }
+    }
+  }
+
+  half ret;
+  memcpy(&ret, &ir, sizeof(half));
+  return ret;
+}

--- a/lib/THC/THCHalf.h
+++ b/lib/THC/THCHalf.h
@@ -1,0 +1,18 @@
+#ifndef THC_HALF_CONVERSION_INC
+#define THC_HALF_CONVERSION_INC
+
+#include "THCGeneral.h"
+
+#if CUDA_VERSION >= 7050
+
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+THC_EXTERNC void THCFloat2Half(THCState *state, half *out, float *in, long len);
+THC_EXTERNC void THCHalf2Float(THCState *state, float *out, half *in, long len);
+THC_EXTERNC half THC_float2half(float a);
+THC_EXTERNC float THC_half2float(half a);
+
+#endif
+
+#endif

--- a/lib/THC/THCStorage.c
+++ b/lib/THC/THCStorage.c
@@ -2,5 +2,7 @@
 #include "THCGeneral.h"
 #include "THAtomic.h"
 
+#include "THCHalf.h"
+
 #include "generic/THCStorage.c"
 #include "THCGenerateAllTypes.h"

--- a/lib/THC/THCStorage.cu
+++ b/lib/THC/THCStorage.cu
@@ -6,5 +6,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 
+#include "THCHalf.h"
+
 #include "generic/THCStorage.cu"
 #include "THCGenerateAllTypes.h"

--- a/lib/THC/THCStorageCopy.c
+++ b/lib/THC/THCStorageCopy.c
@@ -1,5 +1,7 @@
 #include "THCStorageCopy.h"
 #include "THCGeneral.h"
 
+#include "THCHalf.h"
+
 #include "generic/THCStorageCopy.c"
 #include "THCGenerateAllTypes.h"

--- a/lib/THC/THCStorageCopy.cu
+++ b/lib/THC/THCStorageCopy.cu
@@ -1,5 +1,7 @@
 #include "THCStorageCopy.h"
 #include "THCGeneral.h"
 
+#include "THCHalf.h"
+
 #include "generic/THCStorageCopy.cu"
 #include "THCGenerateAllTypes.h"

--- a/lib/THC/THCTensorCopy.c
+++ b/lib/THC/THCTensorCopy.c
@@ -2,5 +2,7 @@
 #include "THCGeneral.h"
 #include "THCTensor.h"
 
+#include "THCHalf.h"
+
 #include "generic/THCTensorCopy.c"
 #include "THCGenerateAllTypes.h"

--- a/lib/THC/THCTensorCopy.cu
+++ b/lib/THC/THCTensorCopy.cu
@@ -1,4 +1,5 @@
 #include "THCApply.cuh"
+#include "THCHalf.h"
 
 inline int curGPU() {
   int curDev;

--- a/lib/THC/generic/THCStorage.c
+++ b/lib/THC/generic/THCStorage.c
@@ -17,18 +17,29 @@ int THCStorage_(elementSize)(THCState *state)
   return sizeof(real);
 }
 
-void THCStorage_(set)(THCState *state, THCStorage *self, long index, real value)
+void THCStorage_(set)(THCState *state, THCStorage *self, long index, hostreal _value)
 {
   THArgCheck((index >= 0) && (index < self->size), 2, "index out of bounds");
+  real value = hostrealToReal(_value);
   THCudaCheck(cudaMemcpy(self->data + index, &value, sizeof(real), cudaMemcpyHostToDevice));
 }
 
-real THCStorage_(get)(THCState *state, const THCStorage *self, long index)
+hostreal THCStorage_(get)(THCState *state, const THCStorage *self, long index)
 {
-  real value;
   THArgCheck((index >= 0) && (index < self->size), 2, "index out of bounds");
+#ifndef THC_REAL_IS_HALF
+  real value;
   THCudaCheck(cudaMemcpy(&value, self->data + index, sizeof(real), cudaMemcpyDeviceToHost));
-  return value;
+  return realToHostreal(value);
+#else
+  float *ret_d;
+  float ret;
+  THCudaCheck(THCudaMalloc(state, (void**)&ret_d, sizeof(float)));
+  THCHalf2Float(state, ret_d, self->data + index, 1);
+  THCudaCheck(cudaMemcpy(&ret, ret_d, sizeof(float), cudaMemcpyDeviceToHost));
+  THCudaFree(state, ret_d);
+  return ret;
+#endif
 }
 
 THCStorage* THCStorage_(new)(THCState *state)
@@ -69,14 +80,14 @@ THCStorage* THCStorage_(newWithSize)(THCState *state, long size)
   }
 }
 
-THCStorage* THCStorage_(newWithSize1)(THCState *state, real data0)
+THCStorage* THCStorage_(newWithSize1)(THCState *state, hostreal data0)
 {
   THCStorage *self = THCStorage_(newWithSize)(state, 1);
   THCStorage_(set)(state, self, 0, data0);
   return self;
 }
 
-THCStorage* THCStorage_(newWithSize2)(THCState *state, real data0, real data1)
+THCStorage* THCStorage_(newWithSize2)(THCState *state, hostreal data0, hostreal data1)
 {
   THCStorage *self = THCStorage_(newWithSize)(state, 2);
   THCStorage_(set)(state, self, 0, data0);
@@ -84,7 +95,7 @@ THCStorage* THCStorage_(newWithSize2)(THCState *state, real data0, real data1)
   return self;
 }
 
-THCStorage* THCStorage_(newWithSize3)(THCState *state, real data0, real data1, real data2)
+THCStorage* THCStorage_(newWithSize3)(THCState *state, hostreal data0, hostreal data1, hostreal data2)
 {
   THCStorage *self = THCStorage_(newWithSize)(state, 3);
   THCStorage_(set)(state, self, 0, data0);
@@ -93,7 +104,7 @@ THCStorage* THCStorage_(newWithSize3)(THCState *state, real data0, real data1, r
   return self;
 }
 
-THCStorage* THCStorage_(newWithSize4)(THCState *state, real data0, real data1, real data2, real data3)
+THCStorage* THCStorage_(newWithSize4)(THCState *state, hostreal data0, hostreal data1, hostreal data2, hostreal data3)
 {
   THCStorage *self = THCStorage_(newWithSize)(state, 4);
   THCStorage_(set)(state, self, 0, data0);

--- a/lib/THC/generic/THCStorage.cu
+++ b/lib/THC/generic/THCStorage.cu
@@ -2,9 +2,10 @@
 #define THC_GENERIC_FILE "generic/THCStorage.cu"
 #else
 
-void THCStorage_(fill)(THCState *state, THCStorage *self, real value)
+void THCStorage_(fill)(THCState *state, THCStorage *self, hostreal _value)
 {
   thrust::device_ptr<real> self_data(self->data);
+  real value = hostrealToReal(_value);
   thrust::fill(
 #if CUDA_VERSION >= 7000
     thrust::cuda::par.on(THCState_getCurrentStream(state)),

--- a/lib/THC/generic/THCStorage.h
+++ b/lib/THC/generic/THCStorage.h
@@ -23,15 +23,15 @@ THC_API long THCStorage_(size)(THCState *state, const THCStorage*);
 THC_API int THCStorage_(elementSize)(THCState *state);
 
 /* slow access -- checks everything */
-THC_API void THCStorage_(set)(THCState *state, THCStorage*, long, real);
-THC_API real THCStorage_(get)(THCState *state, const THCStorage*, long);
+THC_API void THCStorage_(set)(THCState *state, THCStorage*, long, hostreal);
+THC_API hostreal THCStorage_(get)(THCState *state, const THCStorage*, long);
 
 THC_API THCStorage* THCStorage_(new)(THCState *state);
 THC_API THCStorage* THCStorage_(newWithSize)(THCState *state, long size);
-THC_API THCStorage* THCStorage_(newWithSize1)(THCState *state, real);
-THC_API THCStorage* THCStorage_(newWithSize2)(THCState *state, real, real);
-THC_API THCStorage* THCStorage_(newWithSize3)(THCState *state, real, real, real);
-THC_API THCStorage* THCStorage_(newWithSize4)(THCState *state, real, real, real, real);
+THC_API THCStorage* THCStorage_(newWithSize1)(THCState *state, hostreal);
+THC_API THCStorage* THCStorage_(newWithSize2)(THCState *state, hostreal, hostreal);
+THC_API THCStorage* THCStorage_(newWithSize3)(THCState *state, hostreal, hostreal, hostreal);
+THC_API THCStorage* THCStorage_(newWithSize4)(THCState *state, hostreal, hostreal, hostreal, hostreal);
 THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, long size, int shared);
 
 /* takes ownership of data */
@@ -49,6 +49,6 @@ THC_API void THCStorage_(retain)(THCState *state, THCStorage *storage);
 
 THC_API void THCStorage_(free)(THCState *state, THCStorage *storage);
 THC_API void THCStorage_(resize)(THCState *state, THCStorage *storage, long size);
-THC_API void THCStorage_(fill)(THCState *state, THCStorage *storage, real value);
+THC_API void THCStorage_(fill)(THCState *state, THCStorage *storage, hostreal value);
 
 #endif

--- a/lib/THC/generic/THCStorageCopy.c
+++ b/lib/THC/generic/THCStorageCopy.c
@@ -2,12 +2,15 @@
 #define THC_GENERIC_FILE "generic/THCStorageCopy.c"
 #else
 
+#ifndef THC_REAL_IS_HALF
 void THCStorage_(copyCPU)(THCState *state, THCStorage *self, struct THStorage *src)
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
   THCudaCheck(cudaMemcpy(self->data, src->data, self->size * sizeof(real), cudaMemcpyHostToDevice));
 }
+#endif
 
+#ifndef THC_REAL_IS_HALF
 #define TH_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC)                            \
   void THCStorage_(copy##TYPEC)(THCState *state, THCStorage *self, struct TH##TYPEC##Storage *src)  \
   {                                                                      \
@@ -22,6 +25,17 @@ void THCStorage_(copyCPU)(THCState *state, THCStorage *self, struct THStorage *s
       THStorage_(free)(buffer);                                          \
     }                                                                    \
   }
+#else
+#define TH_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC)                            \
+  void THCStorage_(copy##TYPEC)(THCState *state, THCStorage *self, struct TH##TYPEC##Storage *src)  \
+  {                                                                      \
+    THArgCheck(self->size == src->size, 2, "size does not match");       \
+    THCudaStorage *buffer = THCudaStorage_newWithSize(state, src->size); \
+    THCudaStorage_copy##TYPEC(state, buffer, src);                       \
+    THCFloat2Half(state, self->data, buffer->data, src->size);           \
+    THCudaStorage_free(state, buffer);                                   \
+  }
+#endif
 
 TH_CUDA_STORAGE_IMPLEMENT_COPY(Byte)
 TH_CUDA_STORAGE_IMPLEMENT_COPY(Char)
@@ -31,12 +45,15 @@ TH_CUDA_STORAGE_IMPLEMENT_COPY(Long)
 TH_CUDA_STORAGE_IMPLEMENT_COPY(Float)
 TH_CUDA_STORAGE_IMPLEMENT_COPY(Double)
 
+#ifndef THC_REAL_IS_HALF
 void THStorage_(copyCuda)(THCState *state, THStorage *self, struct THCStorage *src)
 {
   THArgCheck(self->size == src->size, 2, "size does not match");
   THCudaCheck(cudaMemcpy(self->data, src->data, self->size * sizeof(real), cudaMemcpyDeviceToHost));
 }
+#endif
 
+#ifndef THC_REAL_IS_HALF
 #define TH_CUDA_STORAGE_IMPLEMENT_COPYTO(TYPEC)                         \
   void TH_CONCAT_4(TH,TYPEC,Storage_copyCuda,Real)(THCState *state, TH##TYPEC##Storage *self, struct THCStorage *src) \
   {                                                                     \
@@ -51,6 +68,17 @@ void THStorage_(copyCuda)(THCState *state, THStorage *self, struct THCStorage *s
       THStorage_(free)(buffer);                                         \
     }                                                                   \
   }
+#else
+#define TH_CUDA_STORAGE_IMPLEMENT_COPYTO(TYPEC)                         \
+  void TH_CONCAT_4(TH,TYPEC,Storage_copyCuda,Real)(THCState *state, TH##TYPEC##Storage *self, struct THCStorage *src) \
+  {                                                                     \
+    THArgCheck(self->size == src->size, 2, "size does not match");      \
+    THCudaStorage *buffer = THCudaStorage_newWithSize(state, src->size);\
+    THCHalf2Float(state, buffer->data, src->data, src->size);           \
+    TH_CONCAT_3(TH,TYPEC,Storage_copyCudaFloat)(state, self, buffer);   \
+    THCudaStorage_free(state, buffer);                                  \
+  }
+#endif
 
 TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Byte)
 TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Char)
@@ -59,5 +87,8 @@ TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Int)
 TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Long)
 TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Float)
 TH_CUDA_STORAGE_IMPLEMENT_COPYTO(Double)
+
+#undef TH_CUDA_STORAGE_IMPLEMENT_COPY
+#undef TH_CUDA_STORAGE_IMPLEMENT_COPYTO
 
 #endif

--- a/lib/THC/generic/THCStorageCopy.cu
+++ b/lib/THC/generic/THCStorageCopy.cu
@@ -21,6 +21,7 @@ void THCStorage_(copyCuda)(THCState *state, THCStorage *self, THCStorage *src)
 
 // conversions are mediated by the CPU
 // yes, this is slow; feel free to write CUDA kernels for this
+#ifndef THC_REAL_IS_HALF
 #define THC_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC,TYPECUDA)                            \
   void THCStorage_(copyCuda##TYPEC)(THCState *state, THCStorage *self, struct THCuda##TYPECUDA##Storage *src)  \
   {                                                                      \
@@ -37,6 +38,21 @@ void THCStorage_(copyCuda)(THCState *state, THCStorage *self, THCStorage *src)
       THStorage_(free)(buffer2);                                         \
     }                                                                    \
   }
+#else
+#define THC_CUDA_STORAGE_IMPLEMENT_COPY(TYPEC,TYPECUDA)                            \
+  void THCStorage_(copyCuda##TYPEC)(THCState *state, THCStorage *self, struct THCuda##TYPECUDA##Storage *src)  \
+  {                                                                      \
+    THArgCheck(self->size == src->size, 2, "size does not match");       \
+    if(THCTypeIdx_(TYPEC) == THCTypeIdxFloat) {                          \
+      THCFloat2Half(state, self->data, (float*) src->data, src->size);   /* cast removes compiler error */     \
+    } else {                                                             \
+      THCudaStorage *buffer = THCudaStorage_newWithSize(state, src->size); \
+      THCudaStorage_copyCuda##TYPEC(state, buffer, src);                 \
+      THCFloat2Half(state, self->data, buffer->data, buffer->size);      \
+      THCudaStorage_free(state, buffer);                                 \
+    }                                                                    \
+  }
+#endif
 
 THC_CUDA_STORAGE_IMPLEMENT_COPY(Byte,Byte)
 THC_CUDA_STORAGE_IMPLEMENT_COPY(Char,Char)
@@ -45,5 +61,24 @@ THC_CUDA_STORAGE_IMPLEMENT_COPY(Int,Int)
 THC_CUDA_STORAGE_IMPLEMENT_COPY(Long,Long)
 THC_CUDA_STORAGE_IMPLEMENT_COPY(Float,)  // i.e. float
 THC_CUDA_STORAGE_IMPLEMENT_COPY(Double,Double)
+
+#if CUDA_VERSION >= 7050
+#define FLOAT_COPY(TYPE) TH_CONCAT_3(TH, CReal, Storage_copyCudaFloat)
+void THCStorage_(copyCudaHalf)(THCState *state, THCStorage *self, struct THCudaHalfStorage *src)
+{
+    if(THCTypeIdx_(Real) == THCTypeIdxHalf) {
+      THCStorage_(copy)(state, self, (THCStorage*) src);   /* cast just removes compiler warning */
+    } else {
+        THArgCheck(self->size == src->size, 2, "size does not match");
+        THCudaStorage *buffer = THCudaStorage_newWithSize(state, src->size);
+        THCHalf2Float(state, buffer->data, src->data, src->size);
+        FLOAT_COPY(Real)(state, self, buffer);
+        THCudaStorage_free(state, buffer);
+    }
+}
+#undef FLOAT_COPY
+#endif // CUDA_VERSION >= 7050
+
+#undef THC_CUDA_STORAGE_IMPLEMENT_COPY
 
 #endif

--- a/lib/THC/generic/THCStorageCopy.h
+++ b/lib/THC/generic/THCStorageCopy.h
@@ -21,7 +21,9 @@ THC_API void THCStorage_(copyCudaInt)(THCState *state, THCStorage *storage, stru
 THC_API void THCStorage_(copyCudaLong)(THCState *state, THCStorage *storage, struct THCudaLongStorage *src);
 THC_API void THCStorage_(copyCudaFloat)(THCState *state, THCStorage *storage, struct THCudaStorage *src);
 THC_API void THCStorage_(copyCudaDouble)(THCState *state, THCStorage *storage, struct THCudaDoubleStorage *src);
-
+#if CUDA_VERSION >= 7050
+THC_API void THCStorage_(copyCudaHalf)(THCState *state, THCStorage *storage, struct THCudaHalfStorage *src);
+#endif
 
 THC_API void TH_CONCAT_2(THByteStorage_copyCuda  , Real)(THCState *state, THByteStorage *self, struct THCStorage *src);
 THC_API void TH_CONCAT_2(THCharStorage_copyCuda  , Real)(THCState *state, THCharStorage *self, struct THCStorage *src);
@@ -30,8 +32,12 @@ THC_API void TH_CONCAT_2(THIntStorage_copyCuda   , Real)(THCState *state, THIntS
 THC_API void TH_CONCAT_2(THLongStorage_copyCuda  , Real)(THCState *state, THLongStorage *self, struct THCStorage *src);
 THC_API void TH_CONCAT_2(THFloatStorage_copyCuda , Real)(THCState *state, THFloatStorage *self, struct THCStorage *src);
 THC_API void TH_CONCAT_2(THDoubleStorage_copyCuda, Real)(THCState *state, THDoubleStorage *self, struct THCStorage *src);
+
+/* There is no THHalfStorage */
+#ifndef THC_REAL_IS_HALF
 THC_API void THStorage_(copyCuda)(THCState *state, THStorage *self, THCStorage *src);
 THC_API void THCStorage_(copyCuda)(THCState *state, THCStorage *self, THCStorage *src);
 THC_API void THCStorage_(copyCPU)(THCState *state, THCStorage *self, THStorage *src);
+#endif
 
 #endif

--- a/lib/THC/generic/THCTensor.c
+++ b/lib/THC/generic/THCTensor.c
@@ -730,56 +730,56 @@ void THCTensor_(rawResize)(THCState *state, THCTensor *self, int nDimension, lon
     self->nDimension = 0;
 }
 
-void THCTensor_(set1d)(THCState *state, THCTensor *tensor, long x0, real value)
+void THCTensor_(set1d)(THCState *state, THCTensor *tensor, long x0, hostreal value)
 {
   THArgCheck(tensor->nDimension == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
 }
 
-real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, long x0)
+hostreal THCTensor_(get1d)(THCState *state, const THCTensor *tensor, long x0)
 {
   THArgCheck(tensor->nDimension == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]);
 }
 
-void THCTensor_(set2d)(THCState *state, THCTensor *tensor, long x0, long x1, real value)
+void THCTensor_(set2d)(THCState *state, THCTensor *tensor, long x0, long x1, hostreal value)
 {
   THArgCheck(tensor->nDimension == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
 }
 
-real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, long x0, long x1)
+hostreal THCTensor_(get2d)(THCState *state, const THCTensor *tensor, long x0, long x1)
 {
   THArgCheck(tensor->nDimension == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]);
 }
 
-void THCTensor_(set3d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, real value)
+void THCTensor_(set3d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, hostreal value)
 {
   THArgCheck(tensor->nDimension == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
 }
 
-real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2)
+hostreal THCTensor_(get3d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2)
 {
   THArgCheck(tensor->nDimension == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
   return THCStorage_(get)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]);
 }
 
-void THCTensor_(set4d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, long x3, real value)
+void THCTensor_(set4d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, long x3, hostreal value)
 {
   THArgCheck(tensor->nDimension == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");
   THCStorage_(set)(state, tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
 }
 
-real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2, long x3)
+hostreal THCTensor_(get4d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2, long x3)
 {
   THArgCheck(tensor->nDimension == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");

--- a/lib/THC/generic/THCTensor.h
+++ b/lib/THC/generic/THCTensor.h
@@ -112,15 +112,15 @@ THC_API void THCTensor_(free)(THCState *state, THCTensor *self);
 THC_API void THCTensor_(freeCopyTo)(THCState *state, THCTensor *self, THCTensor *dst);
 
 /* Slow access methods [check everything] */
-THC_API void THCTensor_(set1d)(THCState *state, THCTensor *tensor, long x0, real value);
-THC_API void THCTensor_(set2d)(THCState *state, THCTensor *tensor, long x0, long x1, real value);
-THC_API void THCTensor_(set3d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, real value);
-THC_API void THCTensor_(set4d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, long x3, real value);
+THC_API void THCTensor_(set1d)(THCState *state, THCTensor *tensor, long x0, hostreal value);
+THC_API void THCTensor_(set2d)(THCState *state, THCTensor *tensor, long x0, long x1, hostreal value);
+THC_API void THCTensor_(set3d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, hostreal value);
+THC_API void THCTensor_(set4d)(THCState *state, THCTensor *tensor, long x0, long x1, long x2, long x3, hostreal value);
 
-THC_API real THCTensor_(get1d)(THCState *state, const THCTensor *tensor, long x0);
-THC_API real THCTensor_(get2d)(THCState *state, const THCTensor *tensor, long x0, long x1);
-THC_API real THCTensor_(get3d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2);
-THC_API real THCTensor_(get4d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2, long x3);
+THC_API hostreal THCTensor_(get1d)(THCState *state, const THCTensor *tensor, long x0);
+THC_API hostreal THCTensor_(get2d)(THCState *state, const THCTensor *tensor, long x0, long x1);
+THC_API hostreal THCTensor_(get3d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2);
+THC_API hostreal THCTensor_(get4d)(THCState *state, const THCTensor *tensor, long x0, long x1, long x2, long x3);
 
 /* CUDA-specific functions */
 THC_API cudaTextureObject_t THCTensor_(getTextureObject)(THCState *state, THCTensor *self);

--- a/lib/THC/generic/THCTensorCopy.h
+++ b/lib/THC/generic/THCTensorCopy.h
@@ -18,6 +18,9 @@ THC_API void THCTensor_(copyCudaInt)(THCState *state, THCTensor *storage, struct
 THC_API void THCTensor_(copyCudaLong)(THCState *state, THCTensor *storage, struct THCudaLongTensor *src);
 THC_API void THCTensor_(copyCudaFloat)(THCState *state, THCTensor *storage, struct THCudaTensor *src);
 THC_API void THCTensor_(copyCudaDouble)(THCState *state, THCTensor *storage, struct THCudaDoubleTensor *src);
+#if CUDA_VERSION >= 7050
+THC_API void THCTensor_(copyCudaHalf)(THCState *state, THCTensor *storage, struct THCudaHalfTensor *src);
+#endif
 
 THC_API void TH_CONCAT_2(THByteTensor_copyCuda  , Real)  (THCState *state, THByteTensor *self, THCTensor *src);
 THC_API void TH_CONCAT_2(THCharTensor_copyCuda  , Real)  (THCState *state, THCharTensor *self, THCTensor *src);
@@ -27,10 +30,14 @@ THC_API void TH_CONCAT_2(THLongTensor_copyCuda  , Real)  (THCState *state, THLon
 THC_API void TH_CONCAT_2(THFloatTensor_copyCuda , Real)  (THCState *state, THFloatTensor *self, THCTensor *src);
 THC_API void TH_CONCAT_2(THDoubleTensor_copyCuda, Real)  (THCState *state, THDoubleTensor *self, THCTensor *src);
 THC_API void THCTensor_(copyCuda) (THCState *state, THCTensor *self, THCTensor *src);
+
+/* There is no THHalfTensor */
+#ifndef THC_REAL_IS_HALF
 THC_API void THTensor_(copyCuda) (THCState *state, THTensor *self, THCTensor *src);
 THC_API void THCTensor_(copyCPU) (THCState *state, THCTensor *self, THTensor *src);
 
 THC_API void THCTensor_(copyAsyncCPU)(THCState *state, THCTensor *self, THTensor *src);
 THC_API void THTensor_(copyAsyncCuda)(THCState *state, THTensor *self, THCTensor *src);
+#endif
 
 #endif

--- a/test/test.lua
+++ b/test/test.lua
@@ -2153,6 +2153,9 @@ function test.cudaTypeCopy()
       {'cudaLong',  'CudaLongTensor'},
       {'cudaDouble','CudaDoubleTensor'},
    }
+   if cutorch.hasHalf then
+      table.insert(types, {'cudaHalf', 'CudaHalfTensor'})
+   end
 
    local N = 100
    local t0 = torch.range(1,12):reshape(3,4)
@@ -2214,6 +2217,9 @@ function test.cudaStorageTypeCopy()
       {'cudaLong',  'CudaLongStorage'},
       {'cudaDouble','CudaDoubleStorage'},
    }
+   if cutorch.hasHalf then
+      table.insert(types, {'cudaHalf', 'CudaStorage'})
+   end
 
    local N = 100
    local t0 = torch.range(1,12):reshape(3,4):storage()

--- a/torch/generic/Storage.c
+++ b/torch/generic/Storage.c
@@ -26,7 +26,7 @@ static int torch_Storage_(new)(lua_State *L)
         THCStorage_(free)(state, storage);
         luaL_error(L, "element at index %d is not a number", i);
       }
-      THCStorage_(set)(state, storage, i-1, (real)lua_tonumber(L, -1));
+      THCStorage_(set)(state, storage, i-1, (hostreal)lua_tonumber(L, -1));
       lua_pop(L, 1);
     }
   }
@@ -118,14 +118,14 @@ static int torch_Storage_(fill)(lua_State *L)
 {
   THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
   double value = luaL_checknumber(L, 2);
-  THCStorage_(fill)(cutorch_getstate(L), storage, (real)value);
+  THCStorage_(fill)(cutorch_getstate(L), storage, (hostreal)value);
   lua_settop(L, 1);
   return 1;
 }
 
 static int torch_Storage_(elementSize)(lua_State *L)
 {
-  lua_pushnumber(L, THStorage_(elementSize)(cutorch_getstate(L)));
+  lua_pushnumber(L, THCStorage_(elementSize)(cutorch_getstate(L)));
   return 1;
 }
 
@@ -143,7 +143,7 @@ static int torch_Storage_(__newindex__)(lua_State *L)
     THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
     long index = luaL_checklong(L, 2) - 1;
     double number = luaL_checknumber(L, 3);
-    THCStorage_(set)(cutorch_getstate(L), storage, index, (real)number);
+    THCStorage_(set)(cutorch_getstate(L), storage, index, (hostreal)number);
     lua_pushboolean(L, 1);
   }
   else
@@ -192,12 +192,18 @@ static int torch_Storage_(totable)(lua_State *L)
 {
   THCState *state = cutorch_getstate(L);
   THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
-  THStorage *host_storage;
   long i;
 
   /* Copy storage from device to host. */
-  host_storage = THStorage_(newWithSize)(THCStorage_(size)(state, storage));
+#ifndef THC_REAL_IS_HALF
+  THStorage *host_storage =
+      THStorage_(newWithSize)(THCStorage_(size)(state, storage));
   THStorage_(copyCuda)(state, host_storage, storage);
+#else
+  THFloatStorage *host_storage =
+      THFloatStorage_newWithSize(THCStorage_(size)(state, storage));
+  THFloatStorage_copyCudaHalf(state, host_storage, storage);
+#endif
 
   lua_newtable(L);
   for(i = 0; i < storage->size; i++)
@@ -205,7 +211,11 @@ static int torch_Storage_(totable)(lua_State *L)
     lua_pushnumber(L, (lua_Number)host_storage->data[i]);
     lua_rawseti(L, -2, i+1);
   }
+#ifndef THC_REAL_IS_HALF
   THStorage_(free)(host_storage);
+#else
+  THFloatStorage_free(host_storage);
+#endif
   return 1;
 }
 

--- a/torch/generic/Tensor.c
+++ b/torch/generic/Tensor.c
@@ -27,7 +27,7 @@ static int torch_Tensor_(size)(lua_State *L)
 
 static int torch_Tensor_(elementSize)(lua_State *L)
 {
-  lua_pushnumber(L, THStorage_(elementSize)(cutorch_getstate(L)));
+  lua_pushnumber(L, THCStorage_(elementSize)(cutorch_getstate(L)));
   return 1;
 }
 
@@ -140,7 +140,7 @@ static int torch_Tensor_(new)(lua_State *L)
           THCTensor_(free)(state, tensor);
           luaL_error(L, "invalid element (not a number)");
         }
-        THCStorage_(set)(state, THCTensor_(storage)(state, tensor), si++, (real)lua_tonumber(L, -1));
+        THCStorage_(set)(state, THCTensor_(storage)(state, tensor), si++, (hostreal)lua_tonumber(L, -1));
         lua_pop(L, 1);
       }
 


### PR DESCRIPTION
This commit adds basic support for half-precision floating-point torch types. For now these only implement basic operations (the same as e.g. CudaDouble{Storage,Tensor}), but it's enough to allow cuDNN or other libraries to work on half precision weights.

There's still much space for improvement:
* `THCudaHalfTensor_copyAsync*` functions are not implemented
* `THCudaHalfStorage_get` is not implemented (requires a fp16->fp32 conversion function for host - to be added later)
* Any copy/conversion (except ones from Cuda{Tensor, Storage} and CudaHalf{Tensor, Storage}) will allocate a temporary float buffer (on the GPU) that has the same number of elements as source and destination. It's just the simplest way to do that, but it's worth reimplementing it in the future, so memory complexity can be reduced.