### PR TITLE
Improve inverse test

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -1677,10 +1677,10 @@ function test.ger()
 end
 
 function test.inverse()
-   local a = torch.randn(5, 5)
+   local a = torch.eye(5):add(torch.Tensor(5, 5):uniform(-0.1, 0.1))
    local i1 = torch.inverse(a)
    local i2 = torch.inverse(a:cuda())
-   tester:assertle((i2 - i1:cuda()):abs():max(), 1e-4, "wrong inverse answer")
+   tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong inverse answer")
 end
 
 if cutorch.magma then


### PR DESCRIPTION
My previous fix of this test, adjusting the numerical precision, wasn't enough to make it stable (it was still failing ~ 1% of the runs). A better solution is to construct the matrix to be well-conditioned, so that inversion is numerically more stable - done here as perturbation of identity matrix. 