### PR TITLE
Add potrs with MAGMA

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -907,6 +907,16 @@ wrap("potrf",
      {{name=Tensor, default=true, returned=true, invisible=true},
       {name=Tensor}})
 
+wrap("potrs",
+     cname("potrs"),
+     {{name=Tensor, returned=true},
+      {name=Tensor},
+      {name=Tensor}},
+     cname("potrs"),
+     {{name=Tensor, default=true, returned=true, invisible=true},
+      {name=Tensor},
+      {name=Tensor}})
+
 wrap("qr",
      cname("qr"),
      {{name=Tensor, returned=true},

--- a/lib/THC/THCTensorMath.h
+++ b/lib/THC/THCTensorMath.h
@@ -95,6 +95,7 @@ THC_API void THCudaTensor_gesvd2(THCState *state, THCudaTensor *ru_, THCudaTenso
 THC_API void THCudaTensor_getri(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
 THC_API void THCudaTensor_potri(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
 THC_API void THCudaTensor_potrf(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
+THC_API void THCudaTensor_potrs(THCState *state, THCudaTensor *rb_, THCudaTensor *a, THCudaTensor *b);
 THC_API void THCudaTensor_qr(THCState *state, THCudaTensor *rq_, THCudaTensor *rr_, THCudaTensor *a);
 
 THC_API void THCudaTensor_cat(THCState *state, THCudaTensor *result, THCudaTensor *ta, THCudaTensor *tb, int dimension);

--- a/test/test.lua
+++ b/test/test.lua
@@ -1792,6 +1792,25 @@ if cutorch.magma then
       tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong potrf answer")
    end
 
+   function test.potrs()
+      local A = torch.Tensor({
+        {1.2705,  0.9971,  0.4948,  0.1389,  0.2381},
+        {0.9971,  0.9966,  0.6752,  0.0686,  0.1196},
+        {0.4948,  0.6752,  1.1434,  0.0314,  0.0582},
+        {0.1389,  0.0686,  0.0314,  0.0270,  0.0526},
+        {0.2381,  0.1196,  0.0582,  0.0526,  0.3957}})
+      local B = torch.Tensor({
+        {0.6219,  0.3439,  0.0431},
+        {0.5642,  0.1756,  0.0153},
+        {0.2334,  0.8594,  0.4103},
+        {0.7556,  0.1966,  0.9637},
+        {0.1420,  0.7185,  0.7476}})
+      local chol = torch.potrf(A)
+      local solve1 = torch.potrs(B, chol)
+      local solve2 = torch.potrs(B:cuda(), chol:cuda())
+      tester:assertle((solve2 - solve1:cuda()):abs():max(), 1e-4, "wrong potrs answer")
+   end
+
    function test.qr()
       local A = torch.Tensor{
          { 0.9023,  1.5967,  0.3388, -0.0746, -0.5717},


### PR DESCRIPTION
Hi, this PR adds `potrs` with MAGMA.

I followed the structure of the existing `potrf` code and copied the
`potrs` argument checks from [THTensorLapack](https://github.com/torch/torch7/blob/37a523e17a8c66785e753bb112eac5f97e6496e9/lib/TH/generic/THTensorLapack.c#L562).
The test compares the output to Torch's CPU version and is passing on my system.

This is my first time modifying `cutorch` and any Torch internals.
Can somebody check that I used `THCudaTensor_newColumnMajor` and `free` correctly?
I used `rb_` as the source for `b_` because  `magma_spotrs_gpu` returns results in `b_data`.
I'm not sure if I should use `th_magma_smalloc_pinned` or `THCudaTensor_newColumnMajor` for `a_data`.

-Brandon.