### PR TITLE
kernel p2p access and non-blocking streams

### DIFF
--- a/init.c
+++ b/init.c
@@ -247,7 +247,8 @@ static int cutorch_reserveStreams(lua_State *L)
 {
   THCState *state = cutorch_getstate(L);
   int numStreams = (int) luaL_checknumber(L, 1);
-  THCState_reserveStreams(state, numStreams);
+  int nonBlocking = lua_toboolean(L, 2);
+  THCState_reserveStreams(state, numStreams, nonBlocking);
 
   return 0;
 }
@@ -647,6 +648,24 @@ static int cutorch_setPeerToPeerAccess(lua_State *L)
   return 0;
 }
 
+static int cutorch_getKernelPeerToPeerAccess(lua_State *L)
+{
+  THCState *state = cutorch_getstate(L);
+  lua_pushboolean(L, THCState_getKernelPeerToPeerAccessEnabled(state));
+
+  return 1;
+}
+
+static int cutorch_setKernelPeerToPeerAccess(lua_State *L)
+{
+  THCState *state = cutorch_getstate(L);
+
+  int val = lua_toboolean(L, -1);
+  THCState_setKernelPeerToPeerAccessEnabled(state, val);
+
+  return 0;
+}
+
 static int cutorch_getMemoryUsage(lua_State *L) {
   size_t freeBytes = 0;
   size_t totalBytes = 0;
@@ -881,6 +900,8 @@ static const struct luaL_Reg cutorch_stuff__ [] = {
   {"getDeviceCount", cutorch_getDeviceCount},
   {"getPeerToPeerAccess", cutorch_getPeerToPeerAccess},
   {"setPeerToPeerAccess", cutorch_setPeerToPeerAccess},
+  {"setKernelPeerToPeerAccess", cutorch_setKernelPeerToPeerAccess},
+  {"getKernelPeerToPeerAccess", cutorch_getKernelPeerToPeerAccess},
   {"getDeviceProperties", cutorch_getDeviceProperties},
   {"getMemoryUsage", cutorch_getMemoryUsage},
   {"setDevice", cutorch_setDevice},

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -79,6 +79,15 @@ typedef struct THCState
      If i accessing allocs on j is enabled, p2pAccess[i][j] is 1; 0 otherwise. */
   int** p2pAccessEnabled;
 
+  /* Is direct cross-kernel p2p access allowed? Normally, only cross-GPU
+     copies are allowed via p2p if p2p access is enabled at all for
+     the pair of GPUs in question, but if this flag is true, then
+     all cross-GPU access checks are disabled, allowing kernels to
+     directly access memory on another GPUs.
+     Note that p2p access must exist and be enabled for the pair of
+     GPUs in question. */
+  int p2pKernelAccessEnabled;
+
   void (*cutorchGCFunction)(void *data);
   void *cutorchGCData;
   long heapSoftmax;
@@ -97,13 +106,20 @@ THC_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAcce
 /* access. */
 THC_API void THCState_setPeerToPeerAccess(THCState* state, int dev, int devToAccess,
                                           int enable);
+
+/* By default, direct in-kernel access to memory on remote GPUs is
+   disabled. When set, this allows direct in-kernel access to remote
+   GPUs where GPU/GPU p2p access is enabled and allowed. */
+THC_API int THCState_getKernelPeerToPeerAccessEnabled(THCState* state);
+THC_API void THCState_setKernelPeerToPeerAccessEnabled(THCState* state, int val);
+
 THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* state);
 
 THC_API void THCMagma_init(THCState *state);
 
 /* State manipulators and accessors */
 THC_API int THCState_getNumDevices(THCState* state);
-THC_API void THCState_reserveStreams(THCState* state, int numStreams);
+THC_API void THCState_reserveStreams(THCState* state, int numStreams, int nonBlocking);
 THC_API int THCState_getNumStreams(THCState* state);
 
 THC_API cudaStream_t THCState_getDeviceStream(THCState *state, int device, int stream);

--- a/test/test.lua
+++ b/test/test.lua
@@ -2983,6 +2983,49 @@ function test.cudaHostTensor()
   tester:asserteq(w:nElement(), 0, 'Expected an empty tensor')
 end
 
+function test.kernelP2PAccess()
+   -- We can only test direct kernel p2p access if we have multiple devices
+   -- and p2p enabled
+   if cutorch.getDeviceCount() < 2 then
+      return
+   end
+
+   if cutorch.getPeerToPeerAccess(1, 2) then
+      -- We should be on device 1 anyways, but just make sure
+      cutorch.setDevice(1)
+      local a = torch.CudaTensor(8):zero()
+      local b = nil
+      cutorch.withDevice(2, function() b = torch.CudaTensor(8):fill(1) end)
+
+      local expected = false
+
+      -- a is on device 1, b is on device 2, so this is a kernel p2p access
+      local function tryAdd()
+         local ok, err = pcall(function() a:add(b) end)
+         tester:assert(ok == expected)
+      end
+
+      -- By default, direct kernel p2p access should be an error
+      cutorch.setKernelPeerToPeerAccess(false)
+      cutorch.withDevice(1, tryAdd)
+      tester:asserteq(a:sum(), 0)
+
+      -- Now enable and try again
+      cutorch.setKernelPeerToPeerAccess(true)
+      expected = true
+      cutorch.withDevice(1, tryAdd)
+      tester:asserteq(a:sum(), 8)
+
+      a:zero()
+
+      -- Turn it back off and check again
+      cutorch.setKernelPeerToPeerAccess(false)
+      expected = false
+      cutorch.withDevice(1, tryAdd)
+      tester:asserteq(a:sum(), 0)
+   end
+end
+
 -- unfortunately, torch.Tester() forgot setUp and tearDown functions.
 -- It would be nice to fix torch.Tester() eventually.
 local function setUp()


### PR DESCRIPTION
Adds a runtime option to allow within-kernel access to the memory space of other GPUs, if device-level p2p access is also enabled. By default, we still disallow direct access, but one can opt out of it (there's still a #define flag that can enable the opt-out, but @soumith told me to keep it in for a little bit).

I didn't add the flag for all pairs of GPUs like the p2p access option; that seems a little overkill to me personally.

Also added an option for `reserveStreams` that allows non-blocking streams to be created.

Updated documentation.
