### PR TITLE
Remove dead storage code

### DIFF
--- a/torch/generic/Storage.c
+++ b/torch/generic/Storage.c
@@ -169,25 +169,6 @@ static int torch_Storage_(__index__)(lua_State *L)
   }
 }
 
-#if defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_BYTE)
-static int torch_Storage_(string)(lua_State *L)
-{
-  THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
-  if(lua_isstring(L, -1))
-  {
-    size_t len = 0;
-    const char *str = lua_tolstring(L, -1, &len);
-    THCStorage_(resize)(cutorch_getstate(L), storage, len);
-    memmove(storage->data, str, len);
-    lua_settop(L, 1);
-  }
-  else
-    lua_pushlstring(L, (char*)storage->data, storage->size);
-
-  return 1; /* either storage or string */
-}
-#endif
-
 static int torch_Storage_(totable)(lua_State *L)
 {
   THCState *state = cutorch_getstate(L);
@@ -253,9 +234,6 @@ static const struct luaL_Reg torch_Storage_(_) [] = {
   {"totable", torch_Storage_(totable)},
   {"write", torch_Storage_(write)},
   {"read", torch_Storage_(read)},
-#if defined(TH_REAL_IS_CHAR) || defined(TH_REAL_IS_BYTE)
-  {"string", torch_Storage_(string)},
-#endif
   {NULL, NULL}
 };
 


### PR DESCRIPTION
It was guarded by TH_REAL... definitions, but only THC headers are used when compiling this file.