### PR TITLE
description that sort orders the 'key' tensor numerically

### DIFF
--- a/lib/THC/THCTensorSort.cu
+++ b/lib/THC/THCTensorSort.cu
@@ -106,6 +106,9 @@ void THCudaTensor_fillSliceWithIndex(THCState* state,
   THCudaCheck(cudaGetLastError());
 }
 
+// In alignment with default sort on a c++ map, this function
+// will permute key and value tensors identically, and
+// in such a way that the 'key' tensor is ordered numerically
 THC_API void THCudaTensor_sortKeyValueInplace(THCState* state,
                                               THCudaTensor* key,
                                               THCudaTensor* value,


### PR DESCRIPTION
This is sort of borderline, but I had to google around for 15-20 minutes to find this information, passing through:
- thrust doc: https://github.com/thrust/thrust/wiki/Quick-Start-Guide#sorting (which states that sort is based on key values, in alignment with behavior in standard library)
- c++ doc: http://www.cplusplus.com/reference/map/map/ (which states that default sort on a map is based on the key values)

Intuitively, I was expecting sort to be by value.

(Edit: sort works on cltorch now :-D )
