### PR TITLE
Fix unchecked memory access when indexing a CudaTensor

### DIFF
--- a/lib/THC/THCTensorIndex.cu
+++ b/lib/THC/THCTensorIndex.cu
@@ -682,6 +682,8 @@ void THCudaTensor_indexSelect_long(THCState *state, THCudaTensor *dst, THCudaTen
 {
   THAssert(THCudaTensor_checkGPU(state, 2, dst, src));
 
+  THArgCheck(indices->nDimension == 1, 3, "Index is supposed to be a vector");
+
   THCudaTensor *indices_ = THCudaTensor_newWithSize1d(state, indices->size[0]);
   THCudaTensor_copyLong(state, indices_, indices);
 


### PR DESCRIPTION
I ran into a segmentation fault when I accidentally tried to index a CudaTensor with an empty LongTensor.

To reproduce:
```
require 'cutorch'
a=torch.CudaTensor({1,2,3})
a:index(1, torch.LongTensor({}))
```

The invalid access happens in line 685 of  lib/THC/THCTensorIndex.cu, when getting size[0] of the indices tensor.

I added a THArgCheck before the access to check for correct dimensions.

-Hani