### PR TITLE
add CMAKE_CXX_FLAGS to rockspec, so we can build on ubuntu 16.04

### DIFF
--- a/rocks/cutorch-scm-1.rockspec
+++ b/rocks/cutorch-scm-1.rockspec
@@ -20,7 +20,7 @@ dependencies = {
 build = {
    type = "command",
    build_command = [[
-cmake -E make_directory build && cd build && cmake .. -DLUALIB=$(LUALIB) -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE) -j$(getconf _NPROCESSORS_ONLN) install
+cmake -E make_directory build && cd build && cmake .. -DLUALIB=$(LUALIB) -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE) -j$(getconf _NPROCESSORS_ONLN) install
 ]],
 	platforms = {
       windows = {


### PR DESCRIPTION
This goes hand in hand iwth this commit to distro https://github.com/hughperkins/distro/commit/357ed7b6d5d3d97ba77dc166d94fe7f3721b0e96 (which you can cherry-pick I guess?), and enables build of cutorhc on 16.04 (not tested yet for cunn, cunnx, cudnn).  Addresses https://github.com/torch/cutorch/issues/401

