### PR TITLE
stop cutorch clobbering cltorch, if `require`d after cltorch

### DIFF
--- a/generic/CTensor.c
+++ b/generic/CTensor.c
@@ -114,8 +114,14 @@ static int TH_CONCAT_3(cutorch_,Real,Tensor_copy)(lua_State *L)
   else if( (src = luaT_toudata(L, 2, "torch.CudaHalfTensor")) )
     THTensor_(copyCudaHalf)(cutorch_getstate(L), tensor, src);
 #endif
-  else
-    luaL_typerror(L, 2, "torch.*Tensor");
+  else {  // call underlying copy, which might have been monkey-patched previously, or might be default
+    luaT_pushmetatable(L, TH_CONCAT_STRING_3(torch.,Real,Tensor));
+    lua_getfield(L, -1, "__torch_copy");
+    lua_remove(L, -2);
+    lua_insert(L, -3);
+    lua_call(L, 2, 1);
+    return 1;
+  }
 
   lua_settop(L, 1);
   return 1;
@@ -248,12 +254,17 @@ void cutorch_Tensor_(init)(lua_State* L)
 
 #ifndef THC_REAL_IS_HALF
   luaT_pushmetatable(L, TH_CONCAT_STRING_3(torch.,Real,Tensor));
+  lua_getfield(L, -1, "copy");  // first store the old function
+  lua_setfield(L, -2, "__torch_copy");
+
   lua_pushcfunction(L, TH_CONCAT_3(cutorch_,Real,Tensor_copy));
   lua_setfield(L, -2, "copy");
   lua_pop(L, 1);
 
   // Register async copy methods.
   luaT_pushmetatable(L, TH_CONCAT_STRING_3(torch.,Real,Tensor));
+  lua_getfield(L, -1, "copyAsync");  // first store the old function
+  lua_setfield(L, -2, "__torch_copyAsync");
   lua_pushcfunction(L, TH_CONCAT_3(cutorch_,Real,Tensor_copyAsyncCuda));
   lua_setfield(L, -2, "copyAsync");
   lua_pop(L, 1);

--- a/test/test_cltorch_coexist.lua
+++ b/test/test_cltorch_coexist.lua
@@ -1,0 +1,29 @@
+-- it has always been supported to load cutorch first, and then cltorch
+-- but loading cltorch first, and then cutorch, causes cutorch to clobber cltorch
+-- this test checks that it does not
+
+-- note that cutorch must NOT have been `require`d prior to running this test, otherwise this
+-- test is no longer valid
+
+assert(cutorch == nil)
+assert(cltorch == nil)
+
+require 'cltorch'
+assert(cltorch ~= nil)
+require 'cutorch'
+assert(cutorch ~= nil)
+
+cla = torch.ClTensor(3,2):uniform()
+print('cla', cla)
+
+cua = torch.CudaTensor(3,2):uniform()
+print('cua', cua)
+
+claf = cla:float()
+cuaf = cua:float()
+
+cla = claf:cl()
+cua = cuaf:cuda()
+
+-- if we got to here, we're probably good :-)
+


### PR DESCRIPTION
This isnt strictly necessary any more, since cltorch now runs from a stable torch distro.  But it might still be nice to add this sometime?

This patch makes the cutorch monkey-patch not overwrite any other module's existing monkey-patching on getmetatable(RealTensor).copy, in the case that `cutorch is`require`d after the other module.
