### PR TITLE
Fix baddbmm for non-contiguous results tensor

### DIFF
--- a/lib/THC/THCTensorMathBlas.cu
+++ b/lib/THC/THCTensorMathBlas.cu
@@ -321,8 +321,9 @@ void THCudaTensor_baddbmm(THCState *state, THCudaTensor *result, float beta, THC
   {
     transpose_result = false;
 
-    result_ = THCudaTensor_newWithSize3d(state, result->size[0], result->size[2], result->size[1]);
-    THCudaTensor_copy(state, result_, result);
+    THCudaTensor *transp_r_ = THCudaTensor_newTranspose(state, result, 1, 2);
+    result_ = THCudaTensor_newClone(state, transp_r_);
+    THCudaTensor_free(state, transp_r_);
     THCudaTensor_transpose(state, result_, NULL, 1, 2);
 
     ldc = result_->stride[2];


### PR DESCRIPTION
Last changes required after https://github.com/torch/torch7/pull/672 , as discussed in https://github.com/torch/torch7/commit/8ae0a217f945606be817b22c6dd848ae9bb230d5#commitcomment-17542668
All tests passes in my machine.