### PR TITLE
add half cwrap type and enable math for CudaHalfTensor

### DIFF
--- a/init.c
+++ b/init.c
@@ -35,6 +35,10 @@ extern void cutorch_CudaIntTensorMath_init(lua_State* L);
 extern void cutorch_CudaLongTensorMath_init(lua_State* L);
 extern void cutorch_CudaTensorMath_init(lua_State* L);
 extern void cutorch_CudaDoubleTensorMath_init(lua_State* L);
+#ifdef CUDA_HALF_TENSOR
+extern void cutorch_CudaHalfTensorMath_init(lua_State* L);
+#endif
+
 
 /*
    Iteration utilities for lists of streams and lists of gpus with streams
@@ -985,6 +989,9 @@ int luaopen_libcutorch(lua_State *L)
   cutorch_CudaLongTensorMath_init(L);
   cutorch_CudaTensorMath_init(L);
   cutorch_CudaDoubleTensorMath_init(L);
+#ifdef CUDA_HALF_TENSOR
+  cutorch_CudaHalfTensorMath_init(L);
+#endif
 
   cutorch_Event_init(L);
 


### PR DESCRIPTION
Checked in the interpreter that the half math works as expected.

cc: @wickedfoo 

```
th -lcutorch

  ______             __   |  Torch7
 /_  __/__  ________/ /   |  Scientific computing for Lua.
  / / / _ \/ __/ __/ _ \  |  Type ? for help
 /_/  \___/_/  \__/_//_/  |  https://github.com/torch
                          |  http://torch.ch

th> a = torch.CudaHalfTensor(10):fill(3)
                                                                      [0.0006s]
th> b = torch.CudaHalfTensor(10):fill(4)
                                                                      [0.0003s]
th> a
 3
 3
 3
 3
 3
 3
 3
 3
 3
 3
[torch.CudaHalfTensor of size 10]

                                                                      [0.0008s]
th> b
 4
 4
 4
 4
 4
 4
 4
 4
 4
 4
[torch.CudaHalfTensor of size 10]

                                                                      [0.0004s]
th> a + b
[string "_RESULT={a + b}"]:1: both torch.CudaHalfTensor and torch.CudaHalfTensor have no addition operator
stack traceback:
        /home/soumith/torch/install/share/lua/5.2/trepl/init.lua:501: in function </home/soumith/torch/install/share/lua/5.2/trepl/init.lua:494>
        [C]: in function '__add'
        [string "_RESULT={a + b}"]:1: in main chunk
        [C]: in function 'xpcall'
        /home/soumith/torch/install/share/lua/5.2/trepl/init.lua:651: in function 'repl'
        ...mith/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:199: in main chunk
        [C]: in ?
                                                                      [0.0002s]
th> a:add(b)
 7
 7
 7
 7
 7
 7
 7
 7
 7
 7
[torch.CudaHalfTensor of size 10]

                                                                      [0.0006s]
```