### PR TITLE
Fix torch.clamp behavior with CudaTensor.

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -1011,7 +1011,7 @@ wrap("multinomial",
 wrap("clamp",
      cname("clamp"),
      {{name=Tensor, default=true, returned=true, method={default='nil'}},
-      {name=Tensor, default=1},
+      {name=Tensor, method={default=1}},
       {name=real},
       {name=real}})
 


### PR DESCRIPTION
torch.clamp mistakely overwrites the tensor parameter instead of returning a new tensor when called with 3 arguments (e.g. torch.clamp(a, 1, 7)), when the tensor is a CudaTensor

Fixes #432