### PR TITLE
Pass CMAKE_CXX_COMPILER to new select_compute_arch.cmake

### DIFF
--- a/cmake/select_compute_arch.cmake
+++ b/cmake/select_compute_arch.cmake
@@ -63,6 +63,7 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
       "}\n")
 
     execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${cufile}"
+                    "-ccbin" ${CMAKE_CXX_COMPILER}
                     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/"
                     RESULT_VARIABLE nvcc_res OUTPUT_VARIABLE nvcc_out
                     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Support passing "CC=gcc-4.8 CXX=g++-4.8" for autodetect in Ubuntu 16.04, otherwise it fails and tries to compile for all archs