### PR TITLE
Improved support for temporary buffers

### DIFF
--- a/lib/THC/generic/THCStorage.h
+++ b/lib/THC/generic/THCStorage.h
@@ -5,6 +5,7 @@
 #define TH_STORAGE_REFCOUNTED 1
 #define TH_STORAGE_RESIZABLE  2
 #define TH_STORAGE_FREEMEM    4
+#define TH_STORAGE_TEMP       8
 
 typedef struct THCStorage
 {

--- a/test/test.lua
+++ b/test/test.lua
@@ -2574,7 +2574,7 @@ function test.cudaStorageTypeCopy()
       {'cudaDouble','CudaDoubleStorage'},
    }
    if cutorch.hasHalf then
-      table.insert(types, {'cudaHalf', 'CudaStorage'})
+      table.insert(types, {'cudaHalf', 'CudaHalfStorage'})
    end
 
    local N = 100

--- a/torch/generic/Storage.c
+++ b/torch/generic/Storage.c
@@ -75,6 +75,14 @@ static int torch_Storage_(retain)(lua_State *L)
   return 0;
 }
 
+static int torch_Storage_(setFlag)(lua_State *L)
+{
+  THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
+  char flag = luaL_checkint(L, 2);
+  THCStorage_(setFlag)(cutorch_getstate(L), storage, flag);
+  return 0;
+}
+
 static int torch_Storage_(free)(lua_State *L)
 {
   THCStorage *storage = luaT_checkudata(L, 1, torch_Storage);
@@ -263,6 +271,7 @@ static const struct luaL_Reg torch_Storage_(_) [] = {
   {"__index__", torch_Storage_(__index__)},
   {"resize", torch_Storage_(resize)},
   {"fill", torch_Storage_(fill)},
+  {"setFlag", torch_Storage_(setFlag)},
   {"copy", torch_Storage_(copy)},
   {"totable", torch_Storage_(totable)},
   {"write", torch_Storage_(write)},


### PR DESCRIPTION
When Storage is used for temp buffers, it should provide the ability of skipping data copy on resize - I have used it in cudnn.