### PR TITLE
Add support for CUDA indexAdd

### DIFF
--- a/lib/THC/generic/THCTensorIndex.cu
+++ b/lib/THC/generic/THCTensorIndex.cu
@@ -130,7 +130,6 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 #undef LARGE_INDEX
 }
 
-#ifdef THC_REAL_IS_FLOAT
 void THCTensor_(indexAdd_long)(THCState *state, THCTensor *dst, int dim, THLongTensor *indices, THCTensor *src)
 {
   THAssert(THCTensor_(checkGPU)(state, 2, dst, src));
@@ -258,7 +257,6 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
 #undef SMALL_INDEX
 #undef LARGE_INDEX
 }
-#endif // #ifdef THC_REAL_IS_FLOAT
 
 void THCTensor_(indexFill_long)(THCState *state, THCTensor *dst, int dim, THLongTensor *indices, real val)
 {

--- a/lib/THC/generic/THCTensorIndex.h
+++ b/lib/THC/generic/THCTensorIndex.h
@@ -3,16 +3,12 @@
 #else
 
 THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
-#ifdef THC_REAL_IS_FLOAT
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
-#endif
 THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, real val);
 THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 
 THC_API void THCTensor_(indexCopy_long)(THCState *state, THCTensor *res_, int dim, THLongTensor *indices, THCTensor *src);
-#ifdef THC_REAL_IS_FLOAT
 THC_API void THCTensor_(indexAdd_long)(THCState *state, THCTensor *res_, int dim, THLongTensor *indices, THCTensor *src);
-#endif
 THC_API void THCTensor_(indexFill_long)(THCState *state, THCTensor *tensor, int dim, THLongTensor *index, real val);
 THC_API void THCTensor_(indexSelect_long)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THLongTensor *index);
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1573,15 +1573,17 @@ function test.indexAddHalf()
    -- additional divergence due to float/half:
    -- half_digits_precision = log10(2^11) ~ 3, reserve another
    -- digit to be safe
-   local old_tolerance = test_tolerance
-   test_tolerance = test_tolerance + 1e-2;
-   local halfOnly = { 'torch.CudaHalfTensor' }
-   local halft2gpu2 = {
-      ['torch.FloatTensor'] = 'torch.CudaHalfTensor',
-      ['torch.LongTensor'] = 'torch.CudaLongTensor'
-   }
-   testIndexAdd(halfOnly, halft2gpu2)
-   local test_tolerance =  old_tolerance
+   if cutorch.hasHalf then
+      local old_tolerance = test_tolerance
+      test_tolerance = test_tolerance + 1e-2;
+      local halfOnly = { 'torch.CudaHalfTensor' }
+      local halft2gpu2 = {
+        ['torch.FloatTensor'] = 'torch.CudaHalfTensor',
+        ['torch.LongTensor'] = 'torch.CudaLongTensor'
+      }
+      testIndexAdd(halfOnly, halft2gpu2)
+      local test_tolerance =  old_tolerance
+  end
 end
 
 function test.indexFill()

--- a/torch/generic/Tensor.c
+++ b/torch/generic/Tensor.c
@@ -504,7 +504,6 @@ static int torch_Tensor_(indexCopy)(lua_State *L)
   return 1;
 }
 
-#ifdef THC_REAL_IS_FLOAT
 static int torch_Tensor_(indexAdd)(lua_State *L)
 {
   int narg = lua_gettop(L);
@@ -552,7 +551,6 @@ static int torch_Tensor_(indexAdd)(lua_State *L)
 
   return 1;
 }
-#endif
 
 static int torch_Tensor_(indexFill)(lua_State *L)
 {
@@ -1401,9 +1399,7 @@ static const struct luaL_Reg torch_Tensor_(_) [] = {
   {"select", torch_Tensor_(select)},
   {"index", torch_Tensor_(indexSelect)},
   {"indexCopy", torch_Tensor_(indexCopy)},
-#ifdef THC_REAL_IS_FLOAT
   {"indexAdd", torch_Tensor_(indexAdd)},
-#endif
   {"indexFill", torch_Tensor_(indexFill)},
   {"transpose", torch_Tensor_(transpose)},
   {"t", torch_Tensor_(t)},


### PR DESCRIPTION
Adds indexAdd via atomicAdd for unsigned char, char, short, long,
half, double.  Integer types are templatized based on sizeof.
Floating point types are implemented via intrinsics.