### PR TITLE
Make some basic THC operations thread-safe

### DIFF
--- a/FFI.lua
+++ b/FFI.lua
@@ -20,14 +20,10 @@ typedef struct THCState
 {
   struct THCRNGState* rngState;
   struct cudaDeviceProp* deviceProperties;
-  cudaStream_t currentStream;
-  cublasHandle_t currentBlasHandle;
   THCCudaResourcesPerDevice* resourcesPerDevice;
   int numDevices;
   int numUserStreams;
   int numUserBlasHandles;
-  int currentPerDeviceStream;
-  int currentPerDeviceBlasHandle;
   struct THAllocator* cudaHostAllocator;
 } THCState;
 

--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -126,6 +126,7 @@ SET(src
     THCStorageCopy.c
     THCTensor.c
     THCTensorCopy.c
+    THCThreadLocal.c
     )
 
 SET(src-cuda

--- a/lib/THC/THCAllocator.c
+++ b/lib/THC/THCAllocator.c
@@ -30,13 +30,8 @@ static void *THCudaHostAllocator_realloc(void* ctx, void* ptr, long size) {
   return ptr;
 }
 
-void THCAllocator_init(THCState *state) {
-  state->cudaHostAllocator = (THAllocator*)malloc(sizeof(THAllocator));
-  state->cudaHostAllocator->malloc = &THCudaHostAllocator_alloc;
-  state->cudaHostAllocator->realloc = &THCudaHostAllocator_realloc;
-  state->cudaHostAllocator->free = &THCudaHostAllocator_free;
-}
-
-void THCAllocator_shutdown(THCState *state) {
-  free(state->cudaHostAllocator);
+void THCAllocator_init(THAllocator *cudaHostAllocator) {
+  cudaHostAllocator->malloc = &THCudaHostAllocator_alloc;
+  cudaHostAllocator->realloc = &THCudaHostAllocator_realloc;
+  cudaHostAllocator->free = &THCudaHostAllocator_free;
 }

--- a/lib/THC/THCAllocator.h
+++ b/lib/THC/THCAllocator.h
@@ -3,7 +3,6 @@
 
 #include "THCGeneral.h"
 
-THC_API void THCAllocator_init(THCState *state);
-THC_API void THCAllocator_shutdown(THCState *state);
+THC_API void THCAllocator_init(THAllocator *state);
 
 #endif

--- a/lib/THC/THCBlas.cu
+++ b/lib/THC/THCBlas.cu
@@ -14,7 +14,9 @@ float THCudaBlas_Sdot(THCState *state, long n, float *x, long incx, float *y, lo
     int i_incx = (int)incx;
     int i_incy = (int)incy;
     float result;
-    THCublasCheck(cublasSdot(THCState_getCurrentBlasHandle(state), i_n, x, i_incx, y, i_incy, &result));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasSdot(handle, i_n, x, i_incx, y, i_incy, &result));
     return result;
   }
 
@@ -35,7 +37,9 @@ double THCudaBlas_Ddot(THCState *state, long n, double *x, long incx, double *y,
     int i_incx = (int)incx;
     int i_incy = (int)incy;
     double result;
-    THCublasCheck(cublasDdot(THCState_getCurrentBlasHandle(state), i_n, x, i_incx, y, i_incy, &result));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasDdot(handle, i_n, x, i_incx, y, i_incy, &result));
     return result;
   }
 
@@ -66,7 +70,9 @@ void THCudaBlas_Sgemv(THCState *state, char trans, long m, long n, float alpha, 
     int i_incx = (int)incx;
     int i_incy = (int)incy;
 
-    THCublasCheck(cublasSgemv(THCState_getCurrentBlasHandle(state), op, i_m, i_n, &alpha, a, i_lda, x, i_incx, &beta, y, i_incy));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasSgemv(handle, op, i_m, i_n, &alpha, a, i_lda, x, i_incx, &beta, y, i_incy));
     return;
   }
   THError("Cublas_Sgemv only supports m, n, lda, incx, incy"
@@ -94,7 +100,9 @@ void THCudaBlas_Dgemv(THCState *state, char trans, long m, long n, double alpha,
     int i_incx = (int)incx;
     int i_incy = (int)incy;
 
-    THCublasCheck(cublasDgemv(THCState_getCurrentBlasHandle(state), op, i_m, i_n, &alpha, a, i_lda, x, i_incx, &beta, y, i_incy));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasDgemv(handle, op, i_m, i_n, &alpha, a, i_lda, x, i_incx, &beta, y, i_incy));
     return;
   }
   THError("Cublas_Dgemv only supports m, n, lda, incx, incy"
@@ -114,7 +122,9 @@ void THCudaBlas_Sger(THCState *state, long m, long n, float alpha, float *x, lon
       int i_incx = (int)incx;
       int i_incy = (int)incy;
 
-      THCublasCheck(cublasSger(THCState_getCurrentBlasHandle(state), i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
+      cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+      cublasSetStream(handle, THCState_getCurrentStream(state));
+      THCublasCheck(cublasSger(handle, i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
       return;
     }
   THError("Cublas_Sger only supports m, n, lda, incx, incy"
@@ -134,7 +144,9 @@ void THCudaBlas_Dger(THCState *state, long m, long n, double alpha, double *x, l
       int i_incx = (int)incx;
       int i_incy = (int)incy;
 
-      THCublasCheck(cublasDger(THCState_getCurrentBlasHandle(state), i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
+      cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+      cublasSetStream(handle, THCState_getCurrentStream(state));
+      THCublasCheck(cublasDger(handle, i_m, i_n, &alpha, x, i_incx, y, i_incy, a, i_lda));
       return;
     }
   THError("Cublas_Dger only supports m, n, lda, incx, incy"
@@ -199,7 +211,9 @@ void THCudaBlas_Sgemm(THCState *state, char transa, char transb, long m, long n,
     int i_ldb = (int)ldb;
     int i_ldc = (int)ldc;
 
-    THCublasCheck(cublasSgemm(THCState_getCurrentBlasHandle(state), opa, opb, i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb, &beta, c, i_ldc));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasSgemm(handle, opa, opb, i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb, &beta, c, i_ldc));
     return;
   }
   THError("Cublas_Sgemm only supports m, n, k, lda, ldb, ldc"
@@ -227,9 +241,12 @@ void THCudaBlas_Hgemm(THCState *state, char transa, char transb, long m, long n,
     int i_ldb = (int)ldb;
     int i_ldc = (int)ldc;
 
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+
     // Check for native Hgemm support
     if (THC_nativeHalfInstructions(state)) {
-      THCublasCheck(cublasHgemm(THCState_getCurrentBlasHandle(state), opa, opb,
+      THCublasCheck(cublasHgemm(handle, opa, opb,
 				i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb,
 				&beta, c, i_ldc));
     } else {
@@ -237,7 +254,7 @@ void THCudaBlas_Hgemm(THCState *state, char transa, char transb, long m, long n,
       float fAlpha = THC_half2float(alpha);
       float fBeta = THC_half2float(beta);
 
-      THCublasCheck(cublasSgemmEx(THCState_getCurrentBlasHandle(state), opa, opb,
+      THCublasCheck(cublasSgemmEx(handle, opa, opb,
 				  i_m, i_n, i_k, &fAlpha,
                                   a, CUDA_R_16F, i_lda, b, CUDA_R_16F,
 				  i_ldb, &fBeta, c, CUDA_R_16F, i_ldc));
@@ -265,7 +282,9 @@ void THCudaBlas_Dgemm(THCState *state, char transa, char transb, long m, long n,
     int i_ldb = (int)ldb;
     int i_ldc = (int)ldc;
 
-    THCublasCheck(cublasDgemm(THCState_getCurrentBlasHandle(state), opa, opb, i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb, &beta, c, i_ldc));
+    cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+    cublasSetStream(handle, THCState_getCurrentStream(state));
+    THCublasCheck(cublasDgemm(handle, opa, opb, i_m, i_n, i_k, &alpha, a, i_lda, b, i_ldb, &beta, c, i_ldc));
     return;
   }
   THError("Cublas_Dgemm only supports m, n, k, lda, ldb, ldc"
@@ -287,7 +306,9 @@ void THCudaBlas_SgemmBatched(THCState *state, char transa, char transb, long m, 
   cublasOperation_t opa = convertTransToCublasOperation(transa);
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
-  THCublasCheck(cublasSgemmBatched(THCState_getCurrentBlasHandle(state),
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasSgemmBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, b, (int)ldb, &beta, c, (int)ldc,
                                    (int)batchCount));
@@ -307,7 +328,9 @@ void THCudaBlas_DgemmBatched(THCState *state, char transa, char transb, long m, 
   cublasOperation_t opa = convertTransToCublasOperation(transa);
   cublasOperation_t opb = convertTransToCublasOperation(transb);
 
-  THCublasCheck(cublasDgemmBatched(THCState_getCurrentBlasHandle(state),
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasDgemmBatched(handle,
                                    opa, opb, (int)m, (int)n, (int)k,
                                    &alpha, a, (int)lda, b, (int)ldb, &beta, c, (int)ldc,
                                    (int)batchCount));
@@ -320,7 +343,9 @@ void THCudaBlas_Sgetrf(THCState *state, int n, float **a, int lda, int *pivot, i
     THError("Cublas_Sgetrf only supports n, lda, batchSize"
             "with the bound [val] <= %d", INT_MAX);
   }
-  THCublasCheck(cublasSgetrfBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, info, batchSize));
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasSgetrfBatched(handle, n, a, lda, pivot, info, batchSize));
 }
 
 void THCudaBlas_Dgetrf(THCState *state, int n, double **a, int lda, int *pivot, int *info, int batchSize) {
@@ -329,7 +354,9 @@ void THCudaBlas_Dgetrf(THCState *state, int n, double **a, int lda, int *pivot, 
     THError("Cublas_Dgetrf only supports n, lda, batchSize"
             "with the bound [val] <= %d", INT_MAX);
   }
-  THCublasCheck(cublasDgetrfBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, info, batchSize));
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasDgetrfBatched(handle, n, a, lda, pivot, info, batchSize));
 }
 
 void THCudaBlas_Sgetri(THCState *state, int n, const float **a, int lda, int *pivot, float **c, int ldc, int *info, int batchSize) {
@@ -339,7 +366,9 @@ void THCudaBlas_Sgetri(THCState *state, int n, const float **a, int lda, int *pi
     THError("Cublas_Sgetri only supports n, lda, ldc, batchSize"
             "with the bound [val] <= %d", INT_MAX);
   }
-  THCublasCheck(cublasSgetriBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, c, ldc, info, batchSize));
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasSgetriBatched(handle, n, a, lda, pivot, c, ldc, info, batchSize));
 }
 
 void THCudaBlas_Dgetri(THCState *state, int n, const double **a, int lda, int *pivot, double **c, int ldc, int *info, int batchSize) {
@@ -349,5 +378,7 @@ void THCudaBlas_Dgetri(THCState *state, int n, const double **a, int lda, int *p
     THError("Cublas_Dgetri only supports n, lda, ldc, batchSize"
             "with the bound [val] <= %d", INT_MAX);
   }
-  THCublasCheck(cublasDgetriBatched(THCState_getCurrentBlasHandle(state), n, a, lda, pivot, c, ldc, info, batchSize));
+  cublasHandle_t handle = THCState_getCurrentBlasHandle(state);
+  cublasSetStream(handle, THCState_getCurrentStream(state));
+  THCublasCheck(cublasDgetriBatched(handle, n, a, lda, pivot, c, ldc, info, batchSize));
 }

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -38,16 +38,6 @@
 
 struct THCRNGState;  /* Random number generator state. */
 
-typedef struct _THCCudaResourcesPerDevice {
-  cudaStream_t* streams;
-  cublasHandle_t* blasHandles;
-  /* Size of scratch space per each stream on this device available */
-  size_t scratchSpacePerStream;
-  /* Device-resident scratch space per stream, used for global memory
-     reduction kernels. */
-  void** devScratchSpacePerStream;
-} THCCudaResourcesPerDevice;
-
 typedef struct _THCDeviceAllocator {
    cudaError_t (*malloc)(void*, void**, size_t, cudaStream_t);
    cudaError_t (*free)(void*, void*);
@@ -57,50 +47,10 @@ typedef struct _THCDeviceAllocator {
 
 
 /* Global state to be held in the cutorch table. */
-typedef struct THCState
-{
-  struct THCRNGState* rngState;
-  struct cudaDeviceProp* deviceProperties;
-  /* Convenience reference to the current stream/handle in use */
-  cudaStream_t currentStream;
-  cublasHandle_t currentBlasHandle;
-  /* Set of all allocated resources. resourcePerDevice[dev]->streams[0] is NULL,
-     which specifies the per-device default stream. blasHandles do not have a
-     default and must be explicitly initialized. We always initialize 1
-     blasHandle but we can use more.
-  */
-  THCCudaResourcesPerDevice* resourcesPerDevice;
-  /* Captured number of devices upon startup; convenience for bounds checking */
-  int numDevices;
-  /* Number of Torch defined resources available, indices 1 ... numStreams */
-  int numUserStreams;
-  int numUserBlasHandles;
-  /* Index of the current selected per-device resource. Actual CUDA resource
-     changes based on the current device, since resources are per-device */
-  int currentPerDeviceStream;
-  int currentPerDeviceBlasHandle;
-  /* Allocator using cudaMallocHost. */
-  THAllocator* cudaHostAllocator;
-  THCDeviceAllocator cudaDeviceAllocator;
+typedef struct THCState THCState;
 
-  /* Table of enabled peer-to-peer access between directed pairs of GPUs.
-     If i accessing allocs on j is enabled, p2pAccess[i][j] is 1; 0 otherwise. */
-  int** p2pAccessEnabled;
-
-  /* Is direct cross-kernel p2p access allowed? Normally, only cross-GPU
-     copies are allowed via p2p if p2p access is enabled at all for
-     the pair of GPUs in question, but if this flag is true, then
-     all cross-GPU access checks are disabled, allowing kernels to
-     directly access memory on another GPUs.
-     Note that p2p access must exist and be enabled for the pair of
-     GPUs in question. */
-  int p2pKernelAccessEnabled;
-
-  void (*cutorchGCFunction)(void *data);
-  void *cutorchGCData;
-  long heapSoftmax;
-  long heapDelta;
-} THCState;
+THC_API THCState* THCState_alloc();
+THC_API void THCState_free(THCState* state);
 
 THC_API void THCudaInit(THCState* state);
 THC_API void THCudaShutdown(THCState* state);
@@ -123,6 +73,10 @@ THC_API void THCState_setKernelPeerToPeerAccessEnabled(THCState* state, int val)
 
 THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* state);
 
+THC_API struct THCRNGState* THCState_getRngState(THCState* state);
+THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
+THC_API THCDeviceAllocator* THCState_getDeviceAllocator(THCState* state);
+
 THC_API void THCMagma_init(THCState *state);
 
 /* State manipulators and accessors */
@@ -133,8 +87,7 @@ THC_API int THCState_getNumStreams(THCState* state);
 THC_API cudaStream_t THCState_getDeviceStream(THCState *state, int device, int stream);
 THC_API cudaStream_t THCState_getCurrentStream(THCState *state);
 THC_API int THCState_getCurrentStreamIndex(THCState *state);
-THC_API void THCState_setStream(THCState *state, int device, int stream);
-THC_API void THCState_setStreamForCurrentDevice(THCState *state, int stream);
+THC_API void THCState_setCurrentStreamIndex(THCState *state, int stream);
 
 THC_API void THCState_reserveBlasHandles(THCState* state, int numHandles);
 THC_API int THCState_getNumBlasHandles(THCState* state);
@@ -142,8 +95,7 @@ THC_API int THCState_getNumBlasHandles(THCState* state);
 THC_API cublasHandle_t THCState_getDeviceBlasHandle(THCState *state, int device, int handle);
 THC_API cublasHandle_t THCState_getCurrentBlasHandle(THCState *state);
 THC_API int THCState_getCurrentBlasHandleIndex(THCState *state);
-THC_API void THCState_setBlasHandle(THCState *state, int device, int handle);
-THC_API void THCState_setBlasHandleForCurrentDevice(THCState *state, int handle);
+THC_API void THCState_setCurrentBlasHandleIndex(THCState *state, int handle);
 
 /* For the current device and stream, returns the allocated scratch space */
 THC_API void* THCState_getCurrentDeviceScratchSpace(THCState* state);

--- a/lib/THC/THCTensorCopy.cu
+++ b/lib/THC/THCTensorCopy.cu
@@ -117,22 +117,11 @@ THC_copyTensor(THCState* state, TensorTypeDst* dst, TensorTypeSrc* src) {
     // A device always has access to itself, so this also handles the
     // case srcDev == dstDev
     if (THCState_getPeerToPeerAccess(state, srcDev, dstDev)) {
-      // Make sure we have the current stream set in THCState, since
-      // pointwise uses that
-      if (srcDev != oldDev) {
-        THCState_setStream(state, srcDev, copyStreamIndex);
-      }
-
       bool succ =
         THC_pointwiseApply2(
           state, dst, src,
           CopyOp<typename TensorUtils<TensorTypeDst>::DataType,
                  typename TensorUtils<TensorTypeSrc>::DataType>());
-
-      // Restore prior THCState stream
-      if (srcDev != oldDev) {
-        THCState_setStream(state, oldDev, copyStreamIndex);
-      }
 
       THArgCheck(succ, 2, CUTORCH_DIM_WARNING);
     } else {
@@ -154,20 +143,11 @@ THC_copyTensor(THCState* state, TensorTypeDst* dst, TensorTypeSrc* src) {
         srcContig = TensorUtils<TensorTypeDst>::newTensor(state);
         TensorUtils<TensorTypeDst>::resizeAs(state, srcContig, dst);
 
-        if (srcDev != oldDev) {
-          THCState_setStream(state, srcDev, copyStreamIndex);
-        }
-
         bool succ =
           THC_pointwiseApply2(
             state, srcContig, src,
             CopyOp<typename TensorUtils<TensorTypeDst>::DataType,
                    typename TensorUtils<TensorTypeSrc>::DataType>());
-
-        // Restore prior THCState stream
-        if (srcDev != oldDev) {
-          THCState_setStream(state, oldDev, copyStreamIndex);
-        }
 
         THArgCheck(succ, 2, CUTORCH_DIM_WARNING);
       }

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -53,7 +53,7 @@ __host__ void createGeneratorState(Generator* gen, unsigned long seed)
 /* Initialize generator array (must be called before any other function) */
 __host__ void THCRandom_init(THCState* state, int devices, int current_device)
 {
-  THCRNGState* rng_state = state->rngState;
+  THCRNGState* rng_state = THCState_getRngState(state);
   rng_state->num_devices = devices;
   rng_state->gen = (Generator*)malloc(rng_state->num_devices * sizeof(Generator));
   for (int i = 0; i < rng_state->num_devices; ++i)
@@ -63,17 +63,12 @@ __host__ void THCRandom_init(THCState* state, int devices, int current_device)
     rng_state->gen[i].gen_states = NULL;
     rng_state->gen[i].kernel_params = NULL;
   }
-  rng_state->current_gen = &rng_state->gen[current_device];
-  // Initialize the generator for the current device. Other generators will be
-  // initialized on-demand in THCRandom_setGenerator.
-  initializeGenerator(state, rng_state->current_gen);
-  THCRandom_seed(state);
 }
 
 /* Destroy generators and free memory */
 __host__ void THCRandom_shutdown(THCState* state)
 {
-  THCRNGState* rng_state = state->rngState;
+  THCRNGState* rng_state = THCState_getRngState(state);
   if (rng_state->gen == NULL) return;
   for (int i = 0; i < rng_state->num_devices; ++i)
   {
@@ -81,20 +76,37 @@ __host__ void THCRandom_shutdown(THCState* state)
   }
   free(rng_state->gen);
   rng_state->gen = NULL;
-  rng_state->current_gen = NULL;
 }
 
-/* Set the generator for the current device */
-__host__ void THCRandom_setGenerator(THCState* state, int device)
+/* Manually set the generator seed */
+__host__ static void THCRandom_manualSeedGen(Generator* gen, unsigned long seed)
 {
-  THCRNGState* rng_state = state->rngState;
+  gen->initial_seed = seed;
+  createGeneratorState(gen, seed);
+  gen->initf = 1;
+}
+
+/* Get the generator for the current device */
+__host__ Generator* THCRandom_getGenerator(THCState* state)
+{
+  THCRNGState* rng_state = THCState_getRngState(state);
+
+  int device;
+  THCudaCheck(cudaGetDevice(&device));
   if (device >= rng_state->num_devices) THError("Invalid device index.");
-  rng_state->current_gen = &rng_state->gen[device];
-  if (rng_state->current_gen->initf == 0)
+
+  Generator* gen = &rng_state->gen[device];
+  if (gen->initf == 0)
   {
-    initializeGenerator(state, rng_state->current_gen);
-    THCRandom_seed(state);
+    initializeGenerator(state, gen);
+    THCRandom_manualSeedGen(gen, (unsigned long)time(0));
   }
+  return gen;
+}
+
+__host__ struct curandStateMtgp32* THCRandom_generatorStates(struct THCState* state)
+{
+  return THCRandom_getGenerator(state)->gen_states;
 }
 
 /* Random seed */
@@ -115,42 +127,31 @@ __host__ unsigned long THCRandom_seedAll(THCState* state)
 /* Manually set the seed */
 __host__ void THCRandom_manualSeed(THCState* state, unsigned long seed)
 {
-  THCRNGState* rng_state = state->rngState;
-  if (rng_state->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
-  rng_state->current_gen->initial_seed = seed;
-  createGeneratorState(rng_state->current_gen, seed);
-  rng_state->current_gen->initf = 1;
+  Generator* gen = THCRandom_getGenerator(state);
+  THCRandom_manualSeedGen(gen, seed);
 }
 
 __host__ void THCRandom_manualSeedAll(THCState* state, unsigned long seed)
 {
-  THCRNGState* rng_state = state->rngState;
+  THCRNGState* rng_state = THCState_getRngState(state);
   int currentDevice;
   THCudaCheck(cudaGetDevice(&currentDevice));
   for (int i = 0; i < rng_state->num_devices; ++i) {
     THCudaCheck(cudaSetDevice(i));
-    THCRandom_setGenerator(state, i);
     THCRandom_manualSeed(state, seed);
   }
   THCudaCheck(cudaSetDevice(currentDevice));
-  THCRandom_setGenerator(state, currentDevice);
 }
 
 /* Get the initial seed */
 __host__ unsigned long THCRandom_initialSeed(THCState* state)
 {
-  return state->rngState->current_gen->initial_seed;
+  return THCRandom_getGenerator(state)->initial_seed;
 }
 
 __host__ void THCRandom_getRNGState(THCState* state, THByteTensor *rng_state)
 {
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
 
   // The RNG state comprises the MTPG32 states and the seed.
   static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
@@ -159,9 +160,9 @@ __host__ void THCRandom_getRNGState(THCState* state, THByteTensor *rng_state)
   THByteTensor_resize1d(rng_state, total_size);
   THArgCheck(THByteTensor_nElement(rng_state) == total_size, 1, "RNG state is wrong size");
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
-  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), state->rngState->current_gen->gen_states,
+  THCudaCheck(cudaMemcpy(THByteTensor_data(rng_state), gen->gen_states,
                          states_size, cudaMemcpyDeviceToHost));
-  memcpy(THByteTensor_data(rng_state) + states_size, &state->rngState->current_gen->initial_seed, seed_size);
+  memcpy(THByteTensor_data(rng_state) + states_size, &gen->initial_seed, seed_size);
 }
 
 __global__ void set_rngstate_kernel(curandStateMtgp32 *state, mtgp32_kernel_params *kernel)
@@ -171,10 +172,7 @@ __global__ void set_rngstate_kernel(curandStateMtgp32 *state, mtgp32_kernel_para
 
 __host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_state)
 {
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
 
   static const size_t states_size = MAX_NUM_BLOCKS * sizeof(curandStateMtgp32);
   static const size_t seed_size = sizeof(unsigned long);
@@ -182,11 +180,11 @@ __host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_state)
   THArgCheck(THByteTensor_nElement(rng_state) == total_size, 1, "RNG state is wrong size");
   THArgCheck(THByteTensor_isContiguous(rng_state), 1, "RNG state must be contiguous");
 
-  THCudaCheck(cudaMemcpy(state->rngState->current_gen->gen_states, THByteTensor_data(rng_state),
+  THCudaCheck(cudaMemcpy(gen->gen_states, THByteTensor_data(rng_state),
                          states_size, cudaMemcpyHostToDevice));
   set_rngstate_kernel<<<1, MAX_NUM_BLOCKS, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, state->rngState->current_gen->kernel_params);
-  memcpy(&state->rngState->current_gen->initial_seed, THByteTensor_data(rng_state) + states_size, seed_size);
+      gen->gen_states, gen->kernel_params);
+  memcpy(&gen->initial_seed, THByteTensor_data(rng_state) + states_size, seed_size);
 }
 
 #define GENERATE_KERNEL1(NAME, ARG1, CURAND_FUNC, TRANSFORM)                   \
@@ -244,16 +242,13 @@ __global__ void generate_log_normal(curandStateMtgp32 *state, int size, float *r
 THC_API void THCudaTensor_uniform(THCState* state, THCudaTensor *self_, double a, double b)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_uniform<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, a, b);
+      gen->gen_states, size, data, a, b);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -261,16 +256,13 @@ THC_API void THCudaTensor_uniform(THCState* state, THCudaTensor *self_, double a
 THC_API void THCudaTensor_bernoulli(THCState* state, THCudaTensor *self_, double p)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_bernoulli<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, p);
+      gen->gen_states, size, data, p);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -278,16 +270,13 @@ THC_API void THCudaTensor_bernoulli(THCState* state, THCudaTensor *self_, double
 THC_API void THCudaTensor_normal(THCState* state, THCudaTensor *self_, double mean, double stdv)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_normal<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, mean, stdv);
+      gen->gen_states, size, data, mean, stdv);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -295,16 +284,14 @@ THC_API void THCudaTensor_normal(THCState* state, THCudaTensor *self_, double me
 THC_API void THCudaTensor_logNormal(THCState* state, THCudaTensor *self_, double mean, double stdv)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
+
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_log_normal<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, mean, stdv);
+      gen->gen_states, size, data, mean, stdv);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -312,16 +299,14 @@ THC_API void THCudaTensor_logNormal(THCState* state, THCudaTensor *self_, double
 THC_API void THCudaTensor_geometric(THCState* state, THCudaTensor *self_, double p)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
+
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_geometric<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, p);
+      gen->gen_states, size, data, p);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -329,16 +314,14 @@ THC_API void THCudaTensor_geometric(THCState* state, THCudaTensor *self_, double
 THC_API void THCudaTensor_exponential(THCState* state, THCudaTensor *self_, double lambda)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
+
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_exponential<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, lambda);
+      gen->gen_states, size, data, lambda);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -346,16 +329,14 @@ THC_API void THCudaTensor_exponential(THCState* state, THCudaTensor *self_, doub
 THC_API void THCudaTensor_cauchy(THCState* state, THCudaTensor *self_, double median, double sigma)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));
-  if (state->rngState->current_gen == NULL)
-  {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
+
   THCudaTensor *self = THCudaTensor_newContiguous(state, self_);
   long size = THCudaTensor_nElement(state, self);
   float *data = THCudaTensor_data(state, self);
 
   generate_cauchy<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      state->rngState->current_gen->gen_states, size, data, median, sigma);
+      gen->gen_states, size, data, median, sigma);
 
   THCudaTensor_freeCopyTo(state, self, self_);
 };
@@ -611,9 +592,7 @@ THC_API void THCudaTensor_multinomial(struct THCState *state,
                                       int with_replacement)
 {
   THAssert(THCudaTensor_checkGPU(state, 2, self, prob_dist));
-  if (state->rngState->current_gen == NULL) {
-    THError("Random number generators have not been initialized.");
-  }
+  Generator* gen = THCRandom_getGenerator(state);
 
   int inputSize = THCudaTensor_nDimension(state, prob_dist);
   THArgCheck(inputSize > 0 && inputSize <= 2, 2,
@@ -710,7 +689,7 @@ THC_API void THCudaTensor_multinomial(struct THCState *state,
 
       sampleMultinomialWithReplacement
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-          state->rngState->current_gen->gen_states,
+          gen->gen_states,
           n_sample,
           THCudaTensor_data(state, self),
           numDist, numCategories,
@@ -743,7 +722,7 @@ THC_API void THCudaTensor_multinomial(struct THCState *state,
         // recalculate our distribution
         sampleMultinomialWithoutReplacement
           <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
-            state->rngState->current_gen->gen_states,
+            gen->gen_states,
             n_sample,
             sample,
             THCudaTensor_data(state, self),

--- a/lib/THC/THCTensorRandom.h
+++ b/lib/THC/THCTensorRandom.h
@@ -14,7 +14,6 @@ typedef struct _Generator {
 typedef struct THCRNGState {
   /* One generator per GPU */
   Generator* gen;
-  Generator* current_gen;
   int num_devices;
 } THCRNGState;
 
@@ -22,7 +21,6 @@ struct THCState;
 
 THC_API void THCRandom_init(struct THCState *state, int num_devices, int current_device);
 THC_API void THCRandom_shutdown(struct THCState *state);
-THC_API void THCRandom_setGenerator(struct THCState *state, int device);
 THC_API unsigned long THCRandom_seed(struct THCState *state);
 THC_API unsigned long THCRandom_seedAll(struct THCState *state);
 THC_API void THCRandom_manualSeed(struct THCState *state, unsigned long the_seed_);
@@ -39,5 +37,7 @@ THC_API void THCudaTensor_cauchy(struct THCState *state, THCudaTensor *self, dou
 THC_API void THCudaTensor_logNormal(struct THCState *state, THCudaTensor *self, double mean, double stdv);
 
 THC_API void THCudaTensor_multinomial(struct THCState *state, THCudaTensor *self, THCudaTensor *prob_dist, int n_sample, int with_replacement);
+
+THC_API struct curandStateMtgp32* THCRandom_generatorStates(struct THCState* state);
 
 #endif

--- a/lib/THC/THCThreadLocal.c
+++ b/lib/THC/THCThreadLocal.c
@@ -1,0 +1,43 @@
+#include "THCThreadLocal.h"
+#include "THCGeneral.h"
+
+
+THCThreadLocal THCThreadLocal_alloc()
+{
+#ifndef _WIN32
+  pthread_key_t key;
+  THAssert(pthread_key_create(&key, NULL) == 0);
+  return key;
+#else
+  DWORD key = TlsAlloc();
+  THAssert(key != TLS_OUT_OF_INDEXES);
+  return key;
+#endif
+}
+
+void THCThreadLocal_free(THCThreadLocal local)
+{
+#ifndef _WIN32
+  THAssert(pthread_key_delete(local) == 0);
+#else
+  THAssert(TlsFree(local));
+#endif
+}
+
+void* THCThreadLocal_get(THCThreadLocal local)
+{
+#ifndef _WIN32
+  return pthread_getspecific(local);
+#else
+  return TlsGetValue(local);
+#endif
+}
+
+void THCThreadLocal_set(THCThreadLocal local, void* value)
+{
+#ifndef _WIN32
+  THAssert(pthread_setspecific(local, value) == 0);
+#else
+  THAssert(TlsSetValue(local, value));
+#endif
+}

--- a/lib/THC/THCThreadLocal.h
+++ b/lib/THC/THCThreadLocal.h
@@ -1,0 +1,16 @@
+#ifndef THC_THREAD_LOCAL_INC
+#define THC_THREAD_LOCAL_INC
+
+#ifdef _WIN32
+typedef DWORD THCThreadLocal;
+#else
+#include <pthread.h>
+typedef pthread_key_t THCThreadLocal;
+#endif
+
+THCThreadLocal THCThreadLocal_alloc();
+void THCThreadLocal_free(THCThreadLocal local);
+void* THCThreadLocal_get(THCThreadLocal local);
+void THCThreadLocal_set(THCThreadLocal local, void* value);
+
+#endif // THC_THREAD_LOCAL_INC


### PR DESCRIPTION
Switching the device, setting the stream, and switching BLAS handles is
now thread-safe. Some other operations, like reserveStreams, are still
not thread-safe.