### PR TITLE
make cunn compile with msvc && fix compilation failure for linux/mac os

### DIFF
--- a/lib/THC/THCDeviceTensor-inl.cuh
+++ b/lib/THC/THCDeviceTensor-inl.cuh
@@ -28,7 +28,11 @@ template <typename T, int Dim,
           typename IndexT, template <typename U> class PtrTraits>
 __host__ __device__
 THCDeviceTensor<T, Dim, IndexT, PtrTraits>::
+#ifdef _MSC_VER
+THCDeviceTensor(DataPtrType data, const IndexT (&sizes)[Dim])
+#else
 THCDeviceTensor(DataPtrType data, const IndexT sizes[Dim])
+#endif
     : data_(data) {
   thc_static_assert(Dim > 0);
 
@@ -46,7 +50,11 @@ template <typename T, int Dim,
           typename IndexT, template <typename U> class PtrTraits>
 __host__ __device__
 THCDeviceTensor<T, Dim, IndexT, PtrTraits>::THCDeviceTensor(
+#ifdef _MSC_VER
+  DataPtrType data, const IndexT (&sizes)[Dim], const IndexT (&strides)[Dim])
+#else
   DataPtrType data, const IndexT sizes[Dim], const IndexT strides[Dim])
+#endif
     : data_(data) {
   thc_static_assert(Dim > 0);
 

--- a/lib/THC/THCDeviceTensor.cuh
+++ b/lib/THC/THCDeviceTensor.cuh
@@ -70,12 +70,21 @@ class THCDeviceTensor {
 
   /// Constructor that calculates strides with no padding
   __host__ __device__ THCDeviceTensor(DataPtrType data,
+#ifdef _MSC_VER
+                                      const IndexT (&sizes)[Dim]);
+#else
                                       const IndexT sizes[Dim]);
+#endif
 
   /// Constructor that takes arbitrary size/stride arrays
   __host__ __device__ THCDeviceTensor(DataPtrType data,
+#ifdef _MSC_VER
+                                      const IndexT (&sizes)[Dim],
+                                      const IndexT (&strides)[Dim]);
+#else
                                       const IndexT sizes[Dim],
                                       const IndexT strides[Dim]);
+#endif
 
   /// Returns true if the two tensors are of the same dimensionality,
   /// size and stride.

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -20,11 +20,14 @@
 #ifdef _WIN32
 # ifdef THC_EXPORTS
 #  define THC_API THC_EXTERNC __declspec(dllexport)
+#  define THC_CLASS __declspec(dllexport)
 # else
 #  define THC_API THC_EXTERNC __declspec(dllimport)
+#  define THC_CLASS __declspec(dllimport)
 # endif
 #else
 # define THC_API THC_EXTERNC
+# define THC_CLASS
 #endif
 
 #ifndef THAssert

--- a/lib/THC/THCHalf.h
+++ b/lib/THC/THCHalf.h
@@ -19,10 +19,10 @@ THC_API half THC_float2half(float a);
 THC_API float THC_half2float(half a);
 
 /* Check for native fp16 support on the current device (CC 5.3+) */
-THC_EXTERNC int THC_nativeHalfInstructions(THCState *state);
+THC_API int THC_nativeHalfInstructions(THCState *state);
 
 /* Check for performant native fp16 support on the current device */
-THC_EXTERNC int THC_fastHalfInstructions(THCState *state);
+THC_API int THC_fastHalfInstructions(THCState *state);
 
 #endif /* CUDA_HALF_TENSOR */
 

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -238,7 +238,7 @@ __global__ void generate_log_normal(curandStateMtgp32 *state, int size, float *r
   }
 }
 
-#define NUM_BLOCKS min(THCCeilDiv(size, (ptrdiff_t) BLOCK_SIZE), (ptrdiff_t) MAX_NUM_BLOCKS)
+#define NUM_BLOCKS min((int)THCCeilDiv(size, (ptrdiff_t) BLOCK_SIZE), MAX_NUM_BLOCKS)
 THC_API void THCudaTensor_uniform(THCState* state, THCudaTensor *self_, double a, double b)
 {
   THAssert(THCudaTensor_checkGPU(state, 1, self_));

--- a/lib/THC/THCTensorTypeUtils.cuh
+++ b/lib/THC/THCTensorTypeUtils.cuh
@@ -33,7 +33,7 @@ struct TensorUtils {
 
 #define TENSOR_UTILS(TENSOR_TYPE, DATA_TYPE, ACC_DATA_TYPE)             \
   template <>                                                           \
-  struct TensorUtils<TENSOR_TYPE> {                                     \
+  struct THC_CLASS TensorUtils<TENSOR_TYPE> {                                     \
     typedef DATA_TYPE DataType;                                         \
     typedef ACC_DATA_TYPE AccDataType;                                  \
                                                                         \

--- a/torch/utils.h
+++ b/torch/utils.h
@@ -17,7 +17,7 @@
 #endif
 
 #ifdef _WIN32
-# ifdef torch_EXPORTS
+# ifdef cutorch_EXPORTS
 #  define TORCH_API TORCH_EXTERNC __declspec(dllexport)
 # else
 #  define TORCH_API TORCH_EXTERNC __declspec(dllimport)


### PR DESCRIPTION
Hi,

I'm very sorry my last PR broke *nix users compilation. This PR includes last PR and fixes to those compilation failures. Since I am not on Linux/Max OS and I can not see full compilation output across those issue descriptions, I hope this PR could really fix those failures. Specifically, the fix includes:
(1) define THC_CLASS for non win32 case, which shoule be the cause of #545
(2) revert an int -> ptrdiff_t change which maybe the cause of #541, #544, #551

I will resend the cunn PR after this cutorch PR is no longer causing compilation issues for Linux/Max OS users. Please send me the error output if you still get compilation error.

Thanks,