### PR TITLE
Fix cutorch.getStream()

### DIFF
--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -559,7 +559,7 @@ int THCState_getCurrentStreamIndex(THCState *state)
   int device;
   THCudaCheck(cudaGetDevice(&device));
   THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, device);
-  for (int i = 0; i < state->numUserStreams; ++i) {
+  for (int i = 0; i <= state->numUserStreams; ++i) {
     if (res->streams[i] == stream) {
       return i;
     }


### PR DESCRIPTION
state->numUserStreams does not include the NULL stream, which is stored
in res->streams[i]