### PR TITLE
allow storages to use custom allocators

### DIFF
--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -123,10 +123,8 @@ ELSE()
 ENDIF()
 
 SET(src
-    THCAllocator.c
     THCCachingAllocator.cpp
     THCGeneral.c
-    THCStorage.c
     THCStorageCopy.c
     THCStream.c
     THCTensor.c

--- a/lib/THC/THCAllocator.c
+++ b/lib/THC/THCAllocator.c
@@ -1,6 +1,6 @@
 #include "THCAllocator.h"
 
-static void *THCudaHostAllocator_alloc(void* ctx, ptrdiff_t size) {
+static void *THCudaHostAllocator_malloc(void* ctx, ptrdiff_t size) {
   void* ptr;
 
   if (size < 0) THError("Invalid memory size: %ld", size);
@@ -18,8 +18,8 @@ static void THCudaHostAllocator_free(void* ctx, void* ptr) {
   THCudaCheck(cudaFreeHost(ptr));
 }
 
-void THCAllocator_init(THAllocator *cudaHostAllocator) {
-  cudaHostAllocator->malloc = &THCudaHostAllocator_alloc;
-  cudaHostAllocator->realloc = NULL;
-  cudaHostAllocator->free = &THCudaHostAllocator_free;
+void THCAllocator_init(THCState *state) {
+  state->cudaHostAllocator->malloc = &THCudaHostAllocator_malloc;
+  state->cudaHostAllocator->realloc = NULL;
+  state->cudaHostAllocator->free = &THCudaHostAllocator_free;
 }

--- a/lib/THC/THCAllocator.h
+++ b/lib/THC/THCAllocator.h
@@ -3,6 +3,6 @@
 
 #include "THCGeneral.h"
 
-THC_API void THCAllocator_init(THAllocator *state);
+THC_API void THCAllocator_init(THCState *state);
 
 #endif

--- a/lib/THC/THCCachingAllocator.cpp
+++ b/lib/THC/THCCachingAllocator.cpp
@@ -300,6 +300,7 @@ static cudaError_t THCCachingAllocator_emptyCache(void* ctx)
 static THCCachingAllocator caching_allocator;
 static THCDeviceAllocator device_allocator = {
   &THCCachingAllocator_malloc,
+  NULL,
   &THCCachingAllocator_free,
   &THCCachingAllocator_emptyCache,
   &caching_allocator

--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -93,6 +93,7 @@ static cudaError_t cudaFreeWrapper(void* ctx, void* devPtr)
 
 static THCDeviceAllocator defaultDeviceAllocator = {
   &cudaMallocWrapper,
+  NULL,
   &cudaFreeWrapper,
   NULL,
   NULL
@@ -129,7 +130,7 @@ void THCudaInit(THCState* state)
   THCRandom_init(state, numDevices, device);
 
   state->cudaHostAllocator = (THAllocator*)malloc(sizeof(THAllocator));
-  THCAllocator_init(state->cudaHostAllocator);
+  THCAllocator_init(state);
 
   /* Enable P2P access between all pairs, if possible */
   THCudaEnablePeerToPeerAccess(state);
@@ -792,3 +793,6 @@ void THCHeapUpdate(THCState *state, ptrdiff_t size) {
 }
 
 #undef GLOBAL_SCRATCH_SPACE_PER_SM_STREAM
+
+#include "THCStorage.c"
+#include "THCAllocator.c"

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -43,7 +43,8 @@ struct THCRNGState;  /* Random number generator state. */
 struct THCStream;
 
 typedef struct _THCDeviceAllocator {
-   cudaError_t (*malloc)(void*, void**, size_t, cudaStream_t);
+   cudaError_t (*malloc)( void*, void**, size_t,         cudaStream_t);
+   cudaError_t (*realloc)(void*, void**, size_t, size_t, cudaStream_t);
    cudaError_t (*free)(void*, void*);
    cudaError_t (*emptyCache)(void*);
    void* state;

--- a/lib/THC/generic/THCStorage.h
+++ b/lib/THC/generic/THCStorage.h
@@ -12,7 +12,7 @@ typedef struct THCStorage
     ptrdiff_t size;
     int refcount;
     char flag;
-    THAllocator *allocator;
+    THCDeviceAllocator *allocator;
     void *allocatorContext;
     struct THCStorage *view;
 } THCStorage;
@@ -37,11 +37,14 @@ THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *fil
 /* takes ownership of data */
 THC_API THCStorage* THCStorage_(newWithData)(THCState *state, real *data, ptrdiff_t size);
 
-THC_API THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
-                                                      THAllocator* allocator,
-                                                      void *allocatorContext);
+THC_API THCStorage* THCStorage_(newWithAllocator)(
+  THCState *state, ptrdiff_t size,
+  THCDeviceAllocator* allocator,
+  void *allocatorContext);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
-    THCState *state, real* data, ptrdiff_t size, THAllocator* allocator, void *allocatorContext);
+  THCState *state, real* data, ptrdiff_t size,
+  THCDeviceAllocator* allocator,
+  void *allocatorContext);
 
 THC_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
 THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);


### PR DESCRIPTION
internal change, fully tested for > 6 months.