### PR TITLE
CMake: Install generic/THCTensorMathScan.h

### DIFF
--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -269,6 +269,8 @@ INSTALL(FILES
           generic/THCTensorMathPointwise.cu
           generic/THCTensorMathReduce.h
           generic/THCTensorMathReduce.cu
+          generic/THCTensorMathScan.h
+          generic/THCTensorMathScan.cu
           generic/THCTensorScatterGather.h
           generic/THCTensorScatterGather.cu
           generic/THCTensorIndex.h


### PR DESCRIPTION
The newly file {{generic/THCTensorMathScan.h}} in commit https://github.com/torch/cutorch/commit/e79ee3e57ad8348ea23c0d749d853f4a8c850626 seems to be missing in CMake install.

Because of that, {{luarocks install cunn}} is failing with:
```
In file included from /home/dinesh/torch/install/include/THC/THC.h:13:0,
                 from /tmp/luarocks_cunn-scm-1-1152/cunn/lib/THCUNN/THCUNN.h:1,
                 from /tmp/luarocks_cunn-scm-1-1152/cunn/lib/THCUNN/VolumetricReplicationPadding.cu:1:
/home/dinesh/torch/install/include/THC/THCTensorMath.h:28:39: fatal error: generic/THCTensorMathScan.h: No such file or directory
```

{{generic/THCTensorMathScan.h}} should be installed so that {{THCTensorMath.h}} can find it.