### PR TITLE
Add supporting code for CUDA IPC

### DIFF
--- a/lib/THC/THC.h
+++ b/lib/THC/THC.h
@@ -4,6 +4,7 @@
 #include "THCGeneral.h"
 #include "THCAllocator.h"
 #include "THCBlas.h"
+#include "THCCachingAllocator.h"
 #include "THCStorage.h"
 #include "THCStorageCopy.h"
 #include "THCStream.h"

--- a/lib/THC/THCAllocator.c
+++ b/lib/THC/THCAllocator.c
@@ -23,3 +23,22 @@ void THCAllocator_init(THCState *state) {
   state->cudaHostAllocator->realloc = NULL;
   state->cudaHostAllocator->free = &THCudaHostAllocator_free;
 }
+
+static cudaError_t THCIpcAllocator_malloc(void* ctx, void** devPtr, size_t size, cudaStream_t stream)
+{
+  THError("THCIpcAllocator.malloc() not supported");
+  return cudaSuccess;
+}
+
+static cudaError_t THCIpcAllocator_free(void* ctx, void* devPtr)
+{
+  return cudaIpcCloseMemHandle(devPtr);
+}
+
+THCDeviceAllocator THCIpcAllocator = {
+  &THCIpcAllocator_malloc,
+  NULL,
+  &THCIpcAllocator_free,
+  NULL,
+  NULL
+};

--- a/lib/THC/THCAllocator.h
+++ b/lib/THC/THCAllocator.h
@@ -5,4 +5,6 @@
 
 THC_API void THCAllocator_init(THCState *state);
 
+extern THCDeviceAllocator THCIpcAllocator;
+
 #endif

--- a/lib/THC/THCCachingAllocator.h
+++ b/lib/THC/THCCachingAllocator.h
@@ -4,5 +4,6 @@
 #include "THCGeneral.h"
 
 THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
+THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
 
 #endif

--- a/lib/THC/generic/THCStorage.c
+++ b/lib/THC/generic/THCStorage.c
@@ -181,6 +181,9 @@ void THCStorage_(free)(THCState *state, THCStorage *self)
       THCudaCheck(
         (*self->allocator->free)(self->allocatorContext, self->data));
     }
+    if(self->flag & TH_STORAGE_VIEW) {
+      THCStorage_(free)(state, self->view);
+    }
     THFree(self);
   }
 }


### PR DESCRIPTION
This adds three small pieces to help with sharing THCStorages across
processes:

 1. THCIpcAllocator: a THCDeviceAllocator to close shared memory handles in the
    child process.
 2. THCCachingAllocator_getBaseAllocation which returns the pointer and
    size of the underlying cudaMalloc allocation. This is necessary
    because cudaIpcGetMemHandle requires 'base' pointers
 3. Support for TH_STORAGE_VIEW in THCStorage_(free). This is useful in
    child processes to represent THCCachingAllocator allocations split
    from a larger cudaMalloc call.