### PR TITLE
THC UVA Allocator

### DIFF
--- a/FFI.lua
+++ b/FFI.lua
@@ -32,6 +32,7 @@ typedef struct THCState
   int numUserStreams;
   int numUserBlasHandles;
   struct THAllocator* cudaHostAllocator;
+  struct THAllocator* cudaUVAAllocator;
 } THCState;
 
 cudaStream_t THCState_getCurrentStream(THCState *state);

--- a/FFI.lua
+++ b/FFI.lua
@@ -32,7 +32,8 @@ typedef struct THCState
   int numUserStreams;
   int numUserBlasHandles;
   struct THAllocator* cudaHostAllocator;
-  struct THAllocator* cudaUVAAllocator;
+  struct THAllocator* cudaUVAHostAllocator;
+  struct THCAllocator* cudaUVADeviceAllocator;
 } THCState;
 
 cudaStream_t THCState_getCurrentStream(THCState *state);

--- a/init.c
+++ b/init.c
@@ -982,6 +982,14 @@ int luaopen_libcutorch(lua_State *L)
   luaT_pushudata(L, THCState_getCudaHostAllocator(state), "torch.Allocator");
   lua_setfield(L, -2, "CudaHostAllocator");
 
+  /* Register torch.CudaUVAHostAllocator. */
+  luaT_pushudata(L, THCState_getCudaUVAHostAllocator(state), "torch.Allocator");
+  lua_setfield(L, -2, "CudaUVAHostAllocator");
+
+  /* Register torch.CudaUVADeviceAllocator. */
+  luaT_pushudata(L, THCState_getCudaUVADeviceAllocator(state), "torch.Allocator");
+  lua_setfield(L, -2, "CudaUVADeviceAllocator");
+
 #ifdef USE_MAGMA
   THCMagma_init(state);
   lua_pushboolean(L, 1);

--- a/init.lua
+++ b/init.lua
@@ -65,8 +65,6 @@ function cutorch.createCudaUVATensor(...)
       size = torch.LongTensor{...}
    end
 
-   print('FOOOOOOOOOO')
-   print('BAAAAAAAAAR')
    print('Use cutorch.CudaUVAAllocator', cutorch.CudaUVADeviceAllocator)
    local storage = torch.CudaStorage(cutorch.CudaUVADeviceAllocator, size:prod())
    print(storage[16])

--- a/init.lua
+++ b/init.lua
@@ -53,6 +53,27 @@ function cutorch.createCudaHostTensor(...)
    return torch.FloatTensor(storage, 1, size:storage())
 end
 
+-- Creates a CudaTensor using the CudaUVAAllocator.
+-- Accepts either a LongStorage or a sequence of numbers.
+function cutorch.createCudaUVATensor(...)
+   local size
+   if not ... then
+      size = torch.LongTensor{0}
+   elseif torch.isStorage(...) then
+      size = torch.LongTensor(...)
+   else
+      size = torch.LongTensor{...}
+   end
+
+   print('FOOOOOOOOOO')
+   print('Use cutorch.CudaUVAAllocator', cutorch.CudaUVADeviceAllocator)
+   local storage = torch.CudaStorage(cutorch.CudaUVADeviceAllocator, size:prod())
+   print(storage[16])
+   local res = torch.CudaTensor(storage):fill(111)
+   print(res[16])
+   return res
+end
+
 -- remove this line to disable automatic cutorch heap-tracking
 -- for garbage collection
 cutorch.setHeapTracking(true)

--- a/init.lua
+++ b/init.lua
@@ -66,6 +66,7 @@ function cutorch.createCudaUVATensor(...)
    end
 
    print('FOOOOOOOOOO')
+   print('BAAAAAAAAAR')
    print('Use cutorch.CudaUVAAllocator', cutorch.CudaUVADeviceAllocator)
    local storage = torch.CudaStorage(cutorch.CudaUVADeviceAllocator, size:prod())
    print(storage[16])

--- a/lib/THC/THCAllocator.c
+++ b/lib/THC/THCAllocator.c
@@ -23,3 +23,38 @@ void THCAllocator_init(THCState *state) {
   state->cudaHostAllocator->realloc = NULL;
   state->cudaHostAllocator->free = &THCudaHostAllocator_free;
 }
+
+static void *THCUVAHostAllocator_alloc(void* ctx, ptrdiff_t size) {
+  void* ptr;
+
+  if (size < 0) THError("Invalid memory size: %ld", size);
+
+  if (size == 0) return NULL;
+
+  THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachHost));
+  return ptr;
+}
+
+static void THCUVAHostAllocator_free(void* ctx, void* ptr) {
+  if (!ptr) return;
+
+  THCudaCheck(cudaFree(ptr));
+}
+
+static void *THCUVAHostAllocator_realloc(void* ctx, void* ptr, ptrdiff_t size) {
+  if (size < 0) THError("Invalid memory size: %ld", size);
+
+  THCUVAHostAllocator_free(ctx, ptr);
+
+  if (size == 0) return NULL;
+
+  THCudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachHost));
+
+  return ptr;
+}
+
+void THCUVAHostAllocator_init(THAllocator *cudaUVAHostAllocator) {
+  cudaUVAHostAllocator->malloc = &THCUVAHostAllocator_alloc;
+  cudaUVAHostAllocator->realloc = &THCUVAHostAllocator_realloc;
+  cudaUVAHostAllocator->free = &THCUVAHostAllocator_free;
+}

--- a/lib/THC/THCAllocator.h
+++ b/lib/THC/THCAllocator.h
@@ -4,5 +4,6 @@
 #include "THCGeneral.h"
 
 THC_API void THCAllocator_init(THCState *state);
+THC_API void THCUVAHostAllocator_init(THAllocator *state);
 
 #endif

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -81,7 +81,9 @@ struct THCState {
 
   /* Allocator using cudaMallocHost. */
   THAllocator* cudaHostAllocator;
+  THAllocator* cudaUVAHostAllocator;
   THCDeviceAllocator* cudaDeviceAllocator;
+  THCDeviceAllocator* cudaUVADeviceAllocator;
 
   /* Index of the current selected BLAS handle. The actual BLAS handle used
      depends on the current device. */
@@ -134,6 +136,8 @@ THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* sta
 
 THC_API struct THCRNGState* THCState_getRngState(THCState* state);
 THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
+THC_API THAllocator* THCState_getCudaUVAHostAllocator(THCState* state);
+THC_API THCDeviceAllocator* THCState_getCudaUVADeviceAllocator(THCState* state);
 THC_API void THCState_setDeviceAllocator(THCState* state, THCDeviceAllocator* allocator);
 
 THC_API void THCMagma_init(THCState *state);

--- a/lib/THC/THCTensorRandom.cu
+++ b/lib/THC/THCTensorRandom.cu
@@ -39,8 +39,10 @@ __host__ void destroyGenerator(THCState *state, Generator* gen)
 /* Creates a new generator state given the seed. */
 __host__ void createGeneratorState(Generator* gen, unsigned long seed)
 {
-  if (curandMakeMTGP32Constants(mtgp32dc_params_fast_11213, gen->kernel_params) != CURAND_STATUS_SUCCESS)
+  int res;
+  if (res = curandMakeMTGP32Constants(mtgp32dc_params_fast_11213, gen->kernel_params) != CURAND_STATUS_SUCCESS)
   {
+    fprintf(stderr, "curandMakeMTGP32Constants %d\n", res);
     THError("Creating MTGP constants failed.");
   }
   if (curandMakeMTGP32KernelState(gen->gen_states, mtgp32dc_params_fast_11213,


### PR DESCRIPTION
This PR adds support for UVA allocation (backed by virtual memory). 

Depending on compute capabilities, perf and coherence vary so I am just adding the possibility to use UVA. 

Since a single allocation results in a pointer that can be used directly both on CPU and GPU, the conversion function only reference the same pointer and never allocate.

Similarly to the current cudaHostAllocator, only Cuda/Float tensors are supported atm.

I have not propagated the pointer passing to the tensor:cuda() and tensor:float() functions, this will be for a future diff.