### PR TITLE
THC UVA Allocator

### DIFF
--- a/init.c
+++ b/init.c
@@ -891,6 +891,24 @@ static int cutorch_setHeapTracking(lua_State *L)
   return 0;
 }
 
+static int cutorch_isManagedPtr(lua_State *L)
+{
+  THCState *state = cutorch_getstate(L);
+  if(lua_type(L, 1) != LUA_TNUMBER) {
+    THError("Must receive a ptr cast as a number");
+  }
+  void* ptr = (void* )luaL_optinteger(L, 1, 0);
+  struct cudaPointerAttributes attributes;
+  cudaError_t res = cudaPointerGetAttributes(&attributes, ptr);
+  if (res == cudaErrorInvalidValue) {
+    lua_pushboolean(L, 0);
+  } else {
+    THCudaCheck(res);
+    lua_pushboolean(L, attributes.isManaged);
+  }
+  return 1;
+}
+
 static int cutorch_shutdown(lua_State *L)
 {
   THCState **state = (THCState **) lua_topointer(L, 1);
@@ -911,11 +929,11 @@ static int cutorch_hasHalfInstructions(lua_State *L) {
 
 static int cutorch_hasFastHalfInstructions(lua_State *L) {
   THCState *state = cutorch_getstate(L);
-#ifdef CUDA_HALF_TENSOR  
+#ifdef CUDA_HALF_TENSOR
   lua_pushboolean(L, THC_fastHalfInstructions(state));
 #else
   lua_pushboolean(L, 0);
-#endif  
+#endif
   return 1;
 }
 
@@ -957,6 +975,7 @@ static const struct luaL_Reg cutorch_stuff__ [] = {
   {"setRNGState", cutorch_setRNGState},
   {"getState", cutorch_getState},
   {"setHeapTracking", cutorch_setHeapTracking},
+  {"isManagedPtr", cutorch_isManagedPtr},
   {NULL, NULL}
 };
 
@@ -981,6 +1000,10 @@ int luaopen_libcutorch(lua_State *L)
   /* Register torch.CudaHostAllocator. */
   luaT_pushudata(L, THCState_getCudaHostAllocator(state), "torch.Allocator");
   lua_setfield(L, -2, "CudaHostAllocator");
+
+  /* Register torch.CudaUVAHostAllocator. */
+  luaT_pushudata(L, THCState_getCudaUVAAllocator(state), "torch.Allocator");
+  lua_setfield(L, -2, "CudaUVAAllocator");
 
 #ifdef USE_MAGMA
   THCMagma_init(state);

--- a/init.lua
+++ b/init.lua
@@ -37,9 +37,7 @@ function cutorch.withDevice(newDeviceID, closure)
     error(unpack(vals, 2))
 end
 
--- Creates a FloatTensor using the CudaHostAllocator.
--- Accepts either a LongStorage or a sequence of numbers.
-function cutorch.createCudaHostTensor(...)
+local function longTensorSize(...)
    local size
    if not ... then
       size = torch.LongTensor{0}
@@ -48,9 +46,90 @@ function cutorch.createCudaHostTensor(...)
    else
       size = torch.LongTensor{...}
    end
+   return size
+end
 
+-- Creates a FloatTensor using the CudaHostAllocator.
+-- Accepts either a LongStorage or a sequence of numbers.
+function cutorch.createCudaHostTensor(...)
+   local size = longTensorSize(...)
    local storage = torch.FloatStorage(cutorch.CudaHostAllocator, size:prod())
    return torch.FloatTensor(storage, 1, size:storage())
+end
+
+-- Creates a CudaTensor using the CudaUVAAllocator.
+-- Accepts either a LongStorage or a sequence of numbers.
+local function _createUVATensor(...)
+   local size = longTensorSize(...)
+   -- See CUDA_C_Programming_guide.pdf for detailed explanation about synchronization
+   -- Section J.
+   -- "It is worth a comment on the synchronization between host and device. Notice how in
+   -- the non-managed example, the synchronous cudaMemcpy() routine is used both to
+   -- synchronize the kernel (that is, to wait for it to finish running), and to transfer the data
+   -- to the host. The Unified Memory examples do not call cudaMemcpy() and so require an
+   -- explicit cudaDeviceSynchronize() before the host program can safely use the output
+   -- from the GPU."
+   -- Section J.2.2.1.
+   -- " Note that if memory is dynamically allocated with cudaMallocManaged() or
+   -- cuMemAllocManaged() while the GPU is active, the behavior of the memory is
+   -- unspecified until additional work is launched or the GPU is synchronized. Attempting
+   -- to access the memory on the CPU during this time may or may not cause a segmentation
+   -- fault."
+   cutorch.synchronize()
+   local storage = torch.FloatStorage(cutorch.CudaUVAAllocator, size:prod())
+   return torch.FloatTensor(storage)
+end
+
+function cutorch.createFloatUVATensor(...)
+   return _createUVATensor(...)
+end
+
+-- Creates a CudaTensor using the CudaUVAAllocator.
+-- Accepts either a LongStorage or a sequence of numbers.
+-- First creates a UVA backed FloatTensor and takes its pointer.
+function cutorch.createCudaUVATensor(...)
+   -- Delegate actual allocation and synchronization to CPU tensor and
+   -- take the pointer.
+   local ft = _createUVATensor(...)
+   local storage = torch.CudaStorage(
+      ft:storage():size(),
+      tonumber(torch.data(ft:storage(), true))
+   )
+   return torch.CudaTensor(storage)
+end
+
+-- UVA storage is a single memory location backed by virtual addressing.
+-- Converting between CPU / GPU tensor types is done by raw pointer passing.
+-- We only support FloatTensor, CudaTensor, Cuda -> float and float -> Cuda atm
+function cutorch.toFloatUVATensor(t)
+   if not torch.isTensor(t) then
+      error('Must use a tensor, got ' .. torch.type(t))
+   end
+   local storage = torch.FloatStorage(
+      t:storage():size(),
+      tonumber(torch.data(t:storage(), true))
+   )
+   assert(cutorch.isManaged(storage))
+   return torch.FloatTensor(storage)
+end
+
+function cutorch.toCudaUVATensor(t)
+   if not torch.isTensor(t) then
+      error('Must use a tensor, got ' .. torch.type(t))
+   end
+   local storage = torch.CudaStorage(
+      t:storage():size(),
+      tonumber(torch.data(t:storage(), true))
+   )
+   assert(cutorch.isManaged(storage))
+   return torch.CudaTensor(storage)
+end
+
+function cutorch.isManaged(t)
+   if not torch.isTensor(t) and not torch.isStorage(t) then
+      error('Usage: cutorch.isManaged(Tensor|Storage), got ' .. torch.type(t))
+   end
+   return cutorch.isManagedPtr(tonumber(torch.data(t, true)))
 end
 
 -- remove this line to disable automatic cutorch heap-tracking

--- a/lib/THC/THCAllocator.h
+++ b/lib/THC/THCAllocator.h
@@ -4,6 +4,7 @@
 #include "THCGeneral.h"
 
 THC_API void THCAllocator_init(THCState *state);
+THC_API void THCUVAAllocator_init(THAllocator *state);
 
 extern THCDeviceAllocator THCIpcAllocator;
 

--- a/lib/THC/THCGeneral.c
+++ b/lib/THC/THCGeneral.c
@@ -11,7 +11,6 @@
 /* Size of scratch space available in global memory per each SM + stream */
 #define GLOBAL_SCRATCH_SPACE_PER_SM_STREAM 4 * sizeof(float)
 
-
 THCCudaResourcesPerDevice* THCState_getDeviceResourcePtr(
   THCState *state, int device);
 
@@ -78,6 +77,9 @@ void THCudaInit(THCState* state)
   state->cudaHostAllocator = (THAllocator*)malloc(sizeof(THAllocator));
   THCAllocator_init(state);
 
+  state->cudaUVAAllocator = (THAllocator*)malloc(sizeof(THAllocator));
+  THCUVAAllocator_init(state->cudaUVAAllocator);
+
   /* Enable P2P access between all pairs, if possible */
   THCudaEnablePeerToPeerAccess(state);
 
@@ -122,6 +124,7 @@ void THCudaShutdown(THCState* state)
 
   free(state->rngState);
   free(state->cudaHostAllocator);
+  free(state->cudaUVAAllocator);
   free(state->deviceProperties);
 
   int deviceCount = 0;
@@ -306,6 +309,11 @@ struct THCRNGState* THCState_getRngState(THCState *state)
 THAllocator* THCState_getCudaHostAllocator(THCState* state)
 {
   return state->cudaHostAllocator;
+}
+
+THAllocator* THCState_getCudaUVAAllocator(THCState* state)
+{
+  return state->cudaUVAAllocator;
 }
 
 void THCState_setDeviceAllocator(THCState* state, THCDeviceAllocator* allocator)

--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -81,6 +81,7 @@ struct THCState {
 
   /* Allocator using cudaMallocHost. */
   THAllocator* cudaHostAllocator;
+  THAllocator* cudaUVAAllocator;
   THCDeviceAllocator* cudaDeviceAllocator;
 
   /* Index of the current selected BLAS handle. The actual BLAS handle used
@@ -134,6 +135,7 @@ THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* sta
 
 THC_API struct THCRNGState* THCState_getRngState(THCState* state);
 THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
+THC_API THAllocator* THCState_getCudaUVAAllocator(THCState* state);
 THC_API void THCState_setDeviceAllocator(THCState* state, THCDeviceAllocator* allocator);
 
 THC_API void THCMagma_init(THCState *state);

--- a/lib/THC/generic/THCStorage.c
+++ b/lib/THC/generic/THCStorage.c
@@ -68,7 +68,8 @@ THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
     // update heap *before* attempting malloc, to free space for the malloc
     THCHeapUpdate(state, size * sizeof(real));
     cudaError_t err =
-      (*allocator->malloc)(allocatorContext, (void**)&(storage->data),
+      (*allocator->malloc)(allocatorContext,
+                           (void**)&(storage->data),
                            size * sizeof(real),
                            THCState_getCurrentStream(state));
     if(err != cudaSuccess){
@@ -76,7 +77,6 @@ THCStorage* THCStorage_(newWithAllocator)(THCState *state, ptrdiff_t size,
       free(storage);
     }
     THCudaCheck(err);
-
   } else {
     storage->data = NULL;
   }


### PR DESCRIPTION
This PR adds support for UVA allocation (backed by virtual memory).

Depending on compute capabilities, perf and coherence vary so I am just adding the possibility to use UVA.

Since a single allocation results in a pointer that can be used directly both on CPU and GPU, the conversion function only reference the same pointer and never allocate.

Similarly to the current cudaHostAllocator, only Cuda/Float tensors are supported atm.

I have not propagated the pointer passing to the tensor:cuda() and tensor:float() functions, future work.
