### PR TITLE
[cutorch potr*] API parity for potr* functions in cutorch

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -1818,28 +1818,34 @@ wrap("inverse",
 wrap("potri",
      cname("potri"),
      {{name=Tensor, returned=true},
-      {name=Tensor}},
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}},
      cname("potri"),
      {{name=Tensor, default=true, returned=true, invisible=true},
-      {name=Tensor}})
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}})
 
 wrap("potrf",
      cname("potrf"),
      {{name=Tensor, returned=true},
-      {name=Tensor}},
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}},
      cname("potrf"),
      {{name=Tensor, default=true, returned=true, invisible=true},
-      {name=Tensor}})
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}})
 
 wrap("potrs",
      cname("potrs"),
      {{name=Tensor, returned=true},
       {name=Tensor},
-      {name=Tensor}},
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}},
      cname("potrs"),
      {{name=Tensor, default=true, returned=true, invisible=true},
       {name=Tensor},
-      {name=Tensor}})
+      {name=Tensor},
+      {name='charoption', values={'U', 'L'}, default='U'}})
 
 wrap("qr",
      cname("qr"),

--- a/lib/THC/THCTensorMath.h
+++ b/lib/THC/THCTensorMath.h
@@ -48,9 +48,9 @@ THC_API void THCudaTensor_geev(THCState *state, THCudaTensor *re_, THCudaTensor 
 THC_API void THCudaTensor_gesvd(THCState *state, THCudaTensor *ru_, THCudaTensor *rs_, THCudaTensor *rv_, THCudaTensor *a, const char *jobu);
 THC_API void THCudaTensor_gesvd2(THCState *state, THCudaTensor *ru_, THCudaTensor *rs_, THCudaTensor *rv_, THCudaTensor *ra_, THCudaTensor *a, const char *jobu);
 THC_API void THCudaTensor_getri(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
-THC_API void THCudaTensor_potri(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
-THC_API void THCudaTensor_potrf(THCState *state, THCudaTensor *ra_, THCudaTensor *a);
-THC_API void THCudaTensor_potrs(THCState *state, THCudaTensor *rb_, THCudaTensor *a, THCudaTensor *b);
+THC_API void THCudaTensor_potri(THCState *state, THCudaTensor *ra_, THCudaTensor *a, const char *uplo);
+THC_API void THCudaTensor_potrf(THCState *state, THCudaTensor *ra_, THCudaTensor *a, const char *uplo);
+THC_API void THCudaTensor_potrs(THCState *state, THCudaTensor *rb_, THCudaTensor *a, THCudaTensor *b, const char *uplo);
 THC_API void THCudaTensor_qr(THCState *state, THCudaTensor *rq_, THCudaTensor *rr_, THCudaTensor *a);
 
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -2419,11 +2419,15 @@ if cutorch.magma then
       }
       A = A * A:t()
 
-      local i1 = torch.potri(A)
-      local i2 = torch.potri(A:cuda())
-      local M = A:cuda() * i2
-      tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong potri answer")
-      tester:assertle((M - torch.eye(A:size(1)):cuda()):abs():max(), 1e-5, "potri not an inverse")
+      for _, triarg in ipairs({'U', 'L'}) do
+          local chol  = torch.potrf(A, triarg)
+
+          local i1 = torch.potri(chol, triarg)
+          local i2 = torch.potri(chol:cuda(), triarg)
+          local M = A:cuda() * i2
+          tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong potri answer")
+          tester:assertle((M - torch.eye(A:size(1)):cuda()):abs():max(), 1e-5, "potri not an inverse")
+      end
    end
 
    function test.potrf()
@@ -2434,9 +2438,11 @@ if cutorch.magma then
          {-0.6738, 0.4734,-1.1123, 2.4071,-1.2756},
          {-3.3883, 0.2807, 0.8161,-1.2756, 4.3415},
       }
-      local i1 = torch.potrf(A)
-      local i2 = torch.potrf(A:cuda())
-      tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong potrf answer")
+      for _, triarg in ipairs({'U', 'L'}) do
+          local i1 = torch.potrf(A, triarg)
+          local i2 = torch.potrf(A:cuda(), triarg)
+          tester:assertle((i2 - i1:cuda()):abs():max(), 1e-5, "wrong potrf answer")
+      end
    end
 
    function test.potrs()
@@ -2452,10 +2458,12 @@ if cutorch.magma then
         {0.2334,  0.8594,  0.4103},
         {0.7556,  0.1966,  0.9637},
         {0.1420,  0.7185,  0.7476}})
-      local chol = torch.potrf(A)
-      local solve1 = torch.potrs(B, chol)
-      local solve2 = torch.potrs(B:cuda(), chol:cuda())
-      tester:assertle((solve2 - solve1:cuda()):abs():max(), 1e-4, "wrong potrs answer")
+      for _, triarg in ipairs({'U', 'L'}) do
+          local chol = torch.potrf(A, triarg)
+          local solve1 = torch.potrs(B, chol, triarg)
+          local solve2 = torch.potrs(B:cuda(), chol:cuda(), triarg)
+          tester:assertle((solve2 - solve1:cuda()):abs():max(), 1e-4, "wrong potrs answer")
+      end
    end
 
    function test.qr()


### PR DESCRIPTION
Addresses https://github.com/torch/cutorch/issues/596, https://github.com/torch/cutorch/issues/579. 

- Potri now expects a call to potrf first. This is consistent with the Torch API: https://github.com/torch/torch7/blob/master/test/test.lua#L2582
- Potr[i|f|s] now accept upper/lower triangular arguments, as supported in torch