### PR TITLE
Process outstanding CUDA events in recordEvent

### DIFF
--- a/lib/THC/THCCachingHostAllocator.cpp
+++ b/lib/THC/THCCachingHostAllocator.cpp
@@ -123,6 +123,12 @@ struct HostAllocator
     Block& block = it->second;
     THAssert(block.allocated);
 
+    // process outstanding cuda events which may have occurred
+    err = processEvents();
+    if (err != cudaSuccess) {
+      return err;
+    }
+
     // create and record an event in the given stream
     cudaEvent_t event;
     err = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);


### PR DESCRIPTION
Without this, the `cuda_events` could continuously grow from calls to
`cudaMemcpyAsync`, but would never be processed if there were no new
pinned memory allocations.

For example:

```lua
 t1 = cutorch.createCudaHostTensor(10)
 t2 = torch.CudaTensor(10)
 while true do t2:copyAsync(t1) end
```