### PR TITLE
Bugfix for multinomial distribution

### DIFF
--- a/lib/THC/THCTensorRandom.cuh
+++ b/lib/THC/THCTensorRandom.cuh
@@ -188,6 +188,9 @@ __device__ int binarySearchForMultinomial(T* dist,
     start = 0;
   }
 
+  T curVal = dist[start];
+  while(start >= 1 && THCNumerics<T>::eq(dist[start - 1], curVal)) start--;
+
   return start;
 }
 


### PR DESCRIPTION
- Ensures the index of the first bin from the cdf is returned.

- potential fix for #636 