### PR TITLE
Enable the CUDA caching allocators by default

### DIFF
--- a/init.c
+++ b/init.c
@@ -1003,8 +1003,9 @@ int luaopen_libcutorch(lua_State *L)
 
   THCState* state = THCState_alloc();
 
+  /* Enable the caching allocator unless THC_CACHING_ALLOCATOR=0 */
   char* thc_caching_allocator = getenv("THC_CACHING_ALLOCATOR");
-  if (thc_caching_allocator && strcmp(thc_caching_allocator, "1") == 0) {
+  if (!thc_caching_allocator || strcmp(thc_caching_allocator, "0") != 0) {
     THCState_setDeviceAllocator(state, THCCachingAllocator_get());
     state->cudaHostAllocator = &THCCachingHostAllocator;
   }


### PR DESCRIPTION
A few of us have been using this extensively without problems. This
avoids synchronizations due to cudaFree calls which makes it much easier
to write performant CUDA code.