### PR TITLE
Make multinomial return a LongTensor (compatible with CPU version)

### DIFF
--- a/TensorMath.lua
+++ b/TensorMath.lua
@@ -971,7 +971,7 @@ for k, Tensor_ in pairs(handledTypenames) do
 
      wrap("multinomial",
           cname("multinomial"),
-          {{name=Tensor, default=true, returned=true, method={default='nil'}},
+          {{name='CudaLongTensor', default=true, returned=true, method={default='nil'}},
            {name=Tensor},
            {name="int"},
            {name="boolean", default=false}})
@@ -1827,7 +1827,7 @@ wrap("randn",
 
 wrap("multinomial",
      cname("multinomial"),
-     {{name=Tensor, default=true, returned=true, method={default='nil'}},
+     {{name='CudaLongTensor', default=true, returned=true, method={default='nil'}},
         {name=Tensor},
         {name="int"},
         {name="boolean", default=false}})

--- a/lib/THC/generic/THCTensorRandom.cu
+++ b/lib/THC/generic/THCTensorRandom.cu
@@ -102,7 +102,7 @@ void THCTensor_(renormRows)(struct THCState* state,
 }
 
 THC_API void THCTensor_(multinomial)(struct THCState *state,
-                                      THCTensor *self,
+                                      THCudaLongTensor *self,
                                       THCTensor *prob_dist,
                                       int n_sample,
                                       int with_replacement)
@@ -144,32 +144,30 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
     THCTensor_(resize2d)(state, probDistContig, 1, numCategories);
   }
 
-  THCTensor_(resize2d)(state, self, numDist, n_sample);
+  THCudaLongTensor_resize2d(state, self, numDist, n_sample);
 
   if (n_sample == 1) {
     // Optimized allocation-free implementation
-
     // To exploit greater parallelism for the sampling, generate the
-    // Uniform random samples in a separate kernel launch, into the
-    // result memory. The device RNG is thread-limited
-    THCTensor_(uniform)(state, self, 0.0, 1.0);
-
+    // Uniform random samples in a separate kernel launch, into
+    // temporarily allocated memory. The device RNG is thread-limited
+    THCTensor *sampled = THCTensor_(newWithSize2d)(state, numDist, n_sample);
+    THCTensor_(uniform)(state, sampled, 0.0, 1.0);
     cudaDeviceProp* props = THCState_getCurrentDeviceProperties(state);
     THAssert(props != NULL);
-
     int numSM = props->multiProcessorCount;
     int maxThreads = props->maxThreadsPerBlock;
-
     dim3 block(numCategories < maxThreads ? numCategories : maxThreads);
     dim3 grid(numDist < numSM * 4 ? numDist : numSM * 4);
-
     sampleMultinomialOnce
       <<<grid, block, block.x * sizeof(real),
          THCState_getCurrentStream(state)>>>(
-      THCTensor_(data)(state, self),
+      THCudaLongTensor_data(state, self),
       numDist,
       numCategories,
+      THCTensor_(data)(state, sampled);
       THCTensor_(data)(state, probDistContig));
+    THCTensor_(free)(sampled);
   } else {
     // Generic, slow implementation with memory allocations
 
@@ -207,7 +205,7 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
         <<<grid, block, 0, THCState_getCurrentStream(state)>>>(
           gen->gen_states,
           n_sample,
-          THCTensor_(data)(state, self),
+          THCudaLongTensor_data(state, self),
           numDist, numCategories,
           THCTensor_(data)(state, prefixSum));
     } else {
@@ -241,7 +239,7 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
             gen->gen_states,
             n_sample,
             sample,
-            THCTensor_(data)(state, self),
+            THCudaLongTensor_data(state, self),
             numDist, numCategories,
             THCTensor_(data)(state, origDist),
             THCTensor_(data)(state, prefixSum));
@@ -255,7 +253,7 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
 
   // Revert data restructuring based on input sizes
   if (inputSize == 1) {
-    THCTensor_(resize1d)(state, self, n_sample);
+    THCudaLongTensor_resize1d(state, self, n_sample);
 
     // Unfortunately, if prob_dist is contiguous already,
     // newContiguous is not a private copy, so we have to restructure

--- a/lib/THC/generic/THCTensorRandom.h
+++ b/lib/THC/generic/THCTensorRandom.h
@@ -11,7 +11,7 @@ THC_API void THCTensor_(normal)(struct THCState *state, THCTensor *self, double 
 THC_API void THCTensor_(logNormal)(struct THCState *state, THCTensor *self, double mean, double stdv);
 THC_API void THCTensor_(exponential)(struct THCState *state, THCTensor *self, double lambda);
 THC_API void THCTensor_(cauchy)(struct THCState *state, THCTensor *self, double median, double sigma);
-THC_API void THCTensor_(multinomial)(struct THCState *state, THCTensor *self, THCTensor *prob_dist, int n_sample, int with_replacement);
+THC_API void THCTensor_(multinomial)(struct THCState *state, THCudaLongTensor *self, THCTensor *prob_dist, int n_sample, int with_replacement);
 
 #endif
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -2989,7 +2989,7 @@ function test.multinomial_without_replacement_gets_all()
          t[dist] = linear
       end
 
-      local orig = t:clone():long()
+      local orig = t:cudaLong()
 
       for _, typename in ipairs(float_typenames) do
           -- Half tensors have precision errors for the binary search causing this test
@@ -3005,7 +3005,7 @@ function test.multinomial_without_replacement_gets_all()
               -- Sort, and we should have the original results, since without replacement
               -- sampling everything, we should have chosen every value uniquely
               result = result:sort(2)
-              tester:assertTensorEq(orig:type(typename), result, 0, "error in multinomial_without_replacement_gets_all")
+              tester:assertTensorEq(orig, result, 0, "error in multinomial_without_replacement_gets_all")
           end
       end
    end


### PR DESCRIPTION
This makes the signature compatible with CPU version, but is a breaking change.

Unfortunately I had to remove an optimized implementation used for sampling a single value without any allocations. It depended on calling `normal` on the result tensor, but it won't work with long outputs.