### PR TITLE
Add THCThrustAllocator.cuh to install files

### DIFF
--- a/lib/THC/CMakeLists.txt
+++ b/lib/THC/CMakeLists.txt
@@ -268,6 +268,7 @@ INSTALL(FILES
           THCTensorTypeUtils.cuh
           THCTensorRandom.cuh
           THCTensorMathMagma.cuh
+          THCThrustAllocator.cuh
           DESTINATION "${THC_INSTALL_INCLUDE_SUBDIR}/THC")
 
 INSTALL(FILES


### PR DESCRIPTION
so downstream projects can use it.