### PR TITLE
Expose a mutex that is held around cudaFree() calls.

### DIFF
--- a/lib/THC/THCCachingAllocator.h
+++ b/lib/THC/THCCachingAllocator.h
@@ -1,9 +1,17 @@
 #ifndef THC_DEVICE_ALLOCATOR_INC
 #define THC_DEVICE_ALLOCATOR_INC
 
+#if __cplusplus >= 201103L
+#include <mutex>
+#endif
+
 #include "THCGeneral.h"
 
 THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
+
+#if __cplusplus >= 201103L
+THC_API std::mutex* THCCachingAllocator_getCudaFreeMutex();
+#endif
 
 #endif


### PR DESCRIPTION
NCCL can deadlock if `cudaFree()` is called while it's launching kernels.
This exposes a mutex that can be held to prevent `cudaFree()` calls in the
caching allocator.