### PR TITLE
Fix sampleMultinomialOnce to better handle large distribution values

### DIFF
--- a/lib/THC/generic/THCTensorRandom.cu
+++ b/lib/THC/generic/THCTensorRandom.cu
@@ -159,8 +159,9 @@ THC_API void THCTensor_(multinomial)(struct THCState *state,
     int maxThreads = props->maxThreadsPerBlock;
     dim3 block(numCategories < maxThreads ? numCategories : maxThreads);
     dim3 grid(numDist < numSM * 4 ? numDist : numSM * 4);
-    sampleMultinomialOnce
-      <<<grid, block, block.x * sizeof(real),
+    sampleMultinomialOnce<real, accreal>
+      <<<grid, block,
+         block.x * (sizeof(real) * sizeof(accreal)),
          THCState_getCurrentStream(state)>>>(
       THCudaLongTensor_data(state, self),
       numDist,


### PR DESCRIPTION
Partially addresses https://github.com/pytorch/pytorch/issues/871. This diff does two things:

1. The multinomial code normalizes the user's probability distributions by summing the values of the distribution and dividing by this sum. Previously, we did not accumulate sums into a type's equivalent Accumulation type (e.g. float for half). This diff changes the kernel to be templatized by the accumulation type, and to use this accumulation type for computing the sum prior to normalization.

2. In the event that the sum of the probability distribution overflows the value that can be handled by its corresponding accumulation type, the value is set to INF. This causes problems down the line in the kernel, whereby the returned sampled index is uninitialized. So this diff adds a device-side assertion that the sum of the probability distribution is not infinity.

Tested using a failure cases sourced from https://github.com/pytorch/pytorch/issues/871:

```
require 'cutorch'

probs = torch.FloatTensor(6):cuda()
probs[1] = 2.1188e38
probs[2] = 1.7152e38
probs[3] = 2.3821e00
probs[4] = 1.0128e00
probs[5] = 1.1600e00
probs[6] = 2.0244e00

print(torch.multinomial(probs, 1))
```

Previously, this would yield some value from uninitialized memory. Now it triggers the device-side assertion.

Additionally, we currently have the accumulation type for floating point Tensors to be floats for performance reasons. I temporarily changed this to double, and re-ran the above script. The script then succeeded in calculating indices.