### PR TITLE
fix indexing bug in sampleMultinomialOnce

### DIFF
--- a/lib/THC/THCTensorRandom.cuh
+++ b/lib/THC/THCTensorRandom.cuh
@@ -134,7 +134,7 @@ sampleMultinomialOnce(long* dest,
     if (THCNumerics<T>::eq(sum,  zero) || THCNumerics<T>::eq(sample, zero)) {
       // Choose the first element
       if (threadIdx.x == 0) {
-        dest[curDist] = 1;
+        dest[curDist] = TH_INDEX_BASE;
       }
 
       continue;


### PR DESCRIPTION
See code - the first element is at TH_INDEX_BASE, whereas the existing implementation is specific to LuaTorch.