### PR TITLE
Enable or disable caching allocator from Lua

### DIFF
--- a/lib/THC/THCGeneral.h.in
+++ b/lib/THC/THCGeneral.h.in
@@ -141,6 +141,8 @@ THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
 THC_API THAllocator* THCState_getCudaUVAAllocator(THCState* state);
 THC_API THCDeviceAllocator* THCState_getDeviceAllocator(THCState* state);
 THC_API void THCState_setDeviceAllocator(THCState* state, THCDeviceAllocator* allocator);
+THC_API int THCState_getCachingAllocator(THCState* state);
+THC_API void THCState_setCachingAllocator(THCState* state, int enable);
 
 THC_API void THCMagma_init(THCState *state);
 


### PR DESCRIPTION
The CUDA caching allocator is now enabled by default but is know to consume more memory (#707). It can be controlled with the `THC_CACHING_ALLOCATOR` environment variable but some applications may want to enforce a value to mitigate their memory usage without user interaction.

Here I propose a simple approach to disable or re-enable the CUDA caching allocator from Lua code.