### PR TITLE
block wide reduction with multiple values to reduce at once

### DIFF
--- a/lib/THC/THCReduceApplyUtils.cuh
+++ b/lib/THC/THCReduceApplyUtils.cuh
@@ -19,59 +19,6 @@ __device__ __forceinline__ IndexType getLinearBlockId() {
     blockIdx.x;
 }
 
-// Block-wide reduction in shared memory helper; only threadIdx.x == 0 will
-// return the reduced value
-template <typename T, typename ReduceOp>
-__device__ T reduceBlock(T* smem,
-                         int numVals,
-                         T threadVal,
-                         ReduceOp reduceOp,
-                         T init) {
-  if (numVals == 0) {
-    return init;
-  }
-
-  if (threadIdx.x < numVals) {
-    smem[threadIdx.x] = threadVal;
-  }
-
-  // First warp will perform reductions across warps
-  __syncthreads();
-  if ((threadIdx.x / warpSize) == 0) {
-    T r = threadIdx.x < numVals ? smem[threadIdx.x] : init;
-
-    for (int i = warpSize + threadIdx.x; i < numVals; i += warpSize) {
-      r = reduceOp(r, smem[i]);
-    }
-
-    smem[threadIdx.x] = r;
-  }
-
-  // First thread will perform reductions across the block
-  __syncthreads();
-
-  T r = init;
-  if (threadIdx.x == 0) {
-    r = smem[0];
-
-    int numLanesParticipating = min(numVals, warpSize);
-
-    if (numLanesParticipating == 32) {
-      // Unroll for warpSize == 32 and numVals >= 32
-#pragma unroll
-      for (int i = 1; i < 32; ++i) {
-        r = reduceOp(r, smem[i]);
-      }
-    } else {
-      for (int i = 1; i < numLanesParticipating; ++i) {
-        r = reduceOp(r, smem[i]);
-      }
-    }
-  }
-
-  return r;
-}
-
 // Return value is in threadVals for threadIdx.x == 0
 template <typename T, typename ReduceOp, int N>
 __device__ void reduceNBlock(T *smem,
@@ -141,6 +88,19 @@ __device__ void reduceNBlock(T *smem,
     }
   }
 }
+
+// Block-wide reduction in shared memory helper; only threadIdx.x == 0 will
+// return the reduced value
+template <typename T, typename ReduceOp>
+__device__ T reduceBlock(T* smem,
+                         int numVals,
+                         T threadVal,
+                         ReduceOp reduceOp,
+                         T init) {
+  reduceNBlock<T, ReduceOp, 1>(smem, &threadVal, numVals, reduceOp, init);
+  return threadVal;
+}
+
 
 // Block-wide reduction where each thread locally reduces N
 // values before letting a single warp take over - assumes

--- a/lib/THC/THCReduceApplyUtils.cuh
+++ b/lib/THC/THCReduceApplyUtils.cuh
@@ -53,7 +53,7 @@ __device__ void reduceNValuesInBlock(T *smem,
   // followed by the 32 outputs for the second threadVal, etc.
   int numLanesParticipating = min(numVals, warpSize);
 
-  if (numVals > warpSize && threadIdx.x < numLanesParticipating) {
+  if (numVals > warpSize && ((threadIdx.x / warpSize) == 0 )) {
 #pragma unroll
     for (int i = 0; i < N; ++i) {
       threadVals[i] = threadIdx.x < numVals ? threadVals[i] : init;

--- a/lib/THC/THCTensorMode.cuh
+++ b/lib/THC/THCTensorMode.cuh
@@ -229,7 +229,7 @@ __global__ void computeMode(
 
   struct ModeUnsignedPair max = {0, 0};
 
-  max = reduceBlockN<struct ModeUnsignedPair, MaxReduceOp<struct ModeUnsignedPair>, 2>
+  max = reduceBlockWithNThreadLocalReductions<struct ModeUnsignedPair, MaxReduceOp<struct ModeUnsignedPair>, 2>
     (uupmem, uup, sliceSize, MaxReduceOp<struct ModeUnsignedPair>(), max);
 
   // Store the mode in shared memory for use in finding the mode in the input slice
@@ -265,7 +265,7 @@ __global__ void computeMode(
   // with the mode.
   struct ModeUnsignedBoolPair match = {0, false};
 
-  match = reduceBlockN<struct ModeUnsignedBoolPair, MatchReduceOp<struct ModeUnsignedBoolPair>, 2>
+  match = reduceBlockWithNThreadLocalReductions<struct ModeUnsignedBoolPair, MatchReduceOp<struct ModeUnsignedBoolPair>, 2>
     (ubpmem, ubpp, sliceSize, MatchReduceOp<struct ModeUnsignedBoolPair>(), match);
 
   // Finally, we have the mode, and an index where it occurs. We use a single thread


### PR DESCRIPTION
This extends reduceBlock so that each thread does N reductions at once. For example, the N=2 reduction of:

(1, 2)
(3, 4)
(5, 6)
(7, 8)

yields (16, 20)