### PR TITLE
Fix abs with char and short cuda types.

### DIFF
--- a/lib/THC/THCNumerics.cuh
+++ b/lib/THC/THCNumerics.cuh
@@ -48,7 +48,7 @@ struct THCNumerics<char> {
   static inline __host__ __device__  char mul(char a, char b) { return a * b; }
   static inline __host__ __device__  char sub(char a, char b) { return a - b; }
   static inline __host__ __device__  char div(char a, char b) { return a / b; }
-  static inline __host__ __device__  char abs(char a) { return abs(a); }
+  static inline __host__ __device__  char abs(char a) { return ::abs((int)a); }
 };
 
 template <>
@@ -67,7 +67,7 @@ struct THCNumerics<short> {
   static inline __host__ __device__  short mul(short a, short b) { return a * b; }
   static inline __host__ __device__  short sub(short a, short b) { return a - b; }
   static inline __host__ __device__  short div(short a, short b) { return a / b; }
-  static inline __host__ __device__  short abs(short a) { return abs(a); }
+  static inline __host__ __device__  short abs(short a) { return ::abs((int)a); }
 };
 
 template <>


### PR DESCRIPTION
Fixes https://github.com/torch/cutorch/issues/746.

I'm not really sure how the current code doesn't infinite loop (compiler optimizes it away?  It infinite loops for me if I try to printf in there).

There are also two abs functions defined: see: http://stackoverflow.com/questions/8226705/g-abs-on-a-short-int-appears-to-turn-it-into-a-double.

We want the int one; the template version doesn't compile since you get errors like: "calling a __host__ function("std::abs<short> ") from a __global__ function("kernelPointwiseApply2< ::Tensor_abs_Short_Op, short, short, unsigned int, (int)-1, (int)2> ") is not allowed"