### PR TITLE
Include THCNumerics.cuh in THCAtomics.cuh.

### DIFF
--- a/lib/THC/THCAtomics.cuh
+++ b/lib/THC/THCAtomics.cuh
@@ -2,6 +2,7 @@
 #define THC_ATOMICS_INC
 
 #include "THCHalf.h"
+#include "THCNumerics.cuh"
 
 template <typename T, size_t n>
 struct AtomicAddIntegerImpl;


### PR DESCRIPTION
THCAtomics.cuh uses THCNumerics.cuh but doesn't include it.