### PR TITLE
Make reduction functors accept only constant arguments

### DIFF
--- a/lib/THC/THCTensorMathReduce.cuh
+++ b/lib/THC/THCTensorMathReduce.cuh
@@ -675,14 +675,14 @@ struct MinValuePair {
 
 template <typename T>
 struct AddOp {
-  __device__ __forceinline__ T operator()(T &lhs, T &rhs) {
+  __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
     return THCNumerics<T>::add(lhs, rhs);
   }
 };
 
 template <typename T>
 struct MulOp {
-  __device__ __forceinline__ T operator()(T &lhs, T &rhs) {
+  __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
     return THCNumerics<T>::mul(lhs, rhs);
   }
 };


### PR DESCRIPTION
(similar to MaxValuePair and MinValuePair above).